### PR TITLE
Actions: use `mv` instead of renameDirectory (fixes #236)

### DIFF
--- a/src/Rules/Actions.hs
+++ b/src/Rules/Actions.hs
@@ -124,7 +124,7 @@ copyDirectory source target = do
 moveDirectory :: FilePath -> FilePath -> Action ()
 moveDirectory source target = do
     putProgressInfo $ renderAction "Move directory" source target
-    liftIO $ IO.renameDirectory source target
+    quietly $ cmd (EchoStdout False) ["mv", source, target]
 
 -- | Transform a given file by applying a function to its contents.
 fixFile :: FilePath -> (String -> String) -> Action ()


### PR DESCRIPTION
Implementing `moveDirectory` by calling into `renameDirectory` is
problematic because it doesn't work across file-systems (e.g., a
tmpfs based `/tmp`).

This fixes the problem by calling into `mv` instead (similarly to
what we do for `copyDirectory`).