### PR TITLE
Check if the output supports colors (fixes #244)

### DIFF
--- a/build.cabal-new.sh
+++ b/build.cabal-new.sh
@@ -55,5 +55,4 @@ popd
 "$root/.shake/build"       \
     --lint                 \
     --directory "$root/.." \
-    --colour               \
     "$@"

--- a/build.cabal.sh
+++ b/build.cabal.sh
@@ -43,5 +43,4 @@ fi
 cabal run hadrian --               \
     --lint                         \
     --directory "$absoluteRoot/.." \
-    --colour                       \
     "$@"

--- a/build.sh
+++ b/build.sh
@@ -49,5 +49,4 @@ ghc                                      \
 "$root/hadrian"            \
     --lint                 \
     --directory "$root/.." \
-    --colour               \
     "$@"

--- a/build.stack.sh
+++ b/build.stack.sh
@@ -36,5 +36,4 @@ stack build --no-library-profiling
 stack exec hadrian --              \
     --lint                         \
     --directory "$absoluteRoot/.." \
-    --colour                       \
     "$@"

--- a/src/Base.hs
+++ b/src/Base.hs
@@ -38,6 +38,7 @@ import Development.Shake hiding (parallel, unit, (*>), Normal)
 import Development.Shake.Classes
 import Development.Shake.FilePath
 import System.Console.ANSI
+import qualified System.Info as Info
 import System.IO
 
 -- TODO: reexport Stage, etc.?
@@ -96,10 +97,17 @@ infixr 6 -/-
 -- | A more colourful version of Shake's putNormal
 putColoured :: Color -> String -> Action ()
 putColoured colour msg = do
-    liftIO $ setSGR [SetColor Foreground Vivid colour]
+    liftIO $ set [SetColor Foreground Vivid colour]
     putNormal msg
-    liftIO $ setSGR []
+    liftIO $ set []
     liftIO $ hFlush stdout
+  where
+    set a = do
+        supported <- hSupportsANSI stdout
+        when (win || supported) $ setSGR a
+    -- An ugly hack to always try to print colours when on mingw and cygwin.
+    -- See: https://github.com/snowleopard/hadrian/pull/253
+    win = "mingw" `isPrefixOf` Info.os || "cygwin" `isPrefixOf` Info.os
 
 -- | Make oracle output more distinguishable
 putOracle :: String -> Action ()


### PR DESCRIPTION
This avoids using colors when the output is, e.g., redirected to a
file. This requried a change to avoid passing the `--colour` flag to
shake (so that hadrian is in charge of colors).

I've also made minor changes to the colors themselves, opting to use
the standard colors (not the bright/vivid ones, otherwise we risk that
for some configurations this will be less readable).

Finally, I've changed the color for `putBuild` - using white
foreground color is problematic (this was not a problem before due to
passing the `--color` flag to shake that was forcing different color).

Signed-off-by: Michal Terepeta <michal.terepeta@gmail.com>