### PR TITLE
Set `THREADS` when running validate

### DIFF
--- a/src/Settings/Builders/Make.hs
+++ b/src/Settings/Builders/Make.hs
@@ -11,4 +11,4 @@ makeBuilderArgs = do
     mconcat
         [ builder (Make gmpBuildPath     ) ? append ["MAKEFLAGS=" ++ j]
         , builder (Make libffiBuildPath  ) ? append ["MAKEFLAGS=" ++ j, "install"]
-        , builder (Make "testsuite/tests") ? arg "fast" ]
+        , builder (Make "testsuite/tests") ? append ["THREADS=" ++ show threads, "fast"]  ]


### PR DESCRIPTION
GHC testsuite uses the `THREADS` env variable (and not the make's `-j`
setting) to control the parallelism. This commit sets THREADS to the
value of `shakeThreads`.