### PR TITLE
Packages/Rts: add `linker` to RTS directories

### DIFF
--- a/src/Rules/Data.hs
+++ b/src/Rules/Data.hs
@@ -104,7 +104,7 @@ buildPackageData context@Context {..} = do
                 orderOnly $ generatedDependencies stage package
                 windows <- windowsHost
                 let prefix = fixKey (buildPath context) ++ "_"
-                    dirs   = [ ".", "hooks", "sm", "eventlog" ]
+                    dirs   = [ ".", "hooks", "sm", "eventlog", "linker" ]
                           ++ [ if windows then "win32" else "posix" ]
                 -- TODO: Adding cmm/S sources to C_SRCS is a hack -- refactor.
                 cSrcs   <- map unifyPath <$>


### PR DESCRIPTION
Recent commit split off the m32 allocator to `rts/linker/`, which
broke the build using Hadrian (since it didn't know about the new
directory). This fixes it.

Signed-off-by: Michal Terepeta <michal.terepeta@gmail.com>