### PR TITLE
Add actions copyDirectoryContent and runBuilderWith

### DIFF
--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -30,6 +30,7 @@ executable hadrian
                        , Oracles.Config.Flag
                        , Oracles.Config.Setting
                        , Oracles.Dependencies
+                       , Oracles.DirectoryContent
                        , Oracles.LookupInPath
                        , Oracles.ModuleFiles
                        , Oracles.PackageData

--- a/src/Oracles/DirectoryContent.hs
+++ b/src/Oracles/DirectoryContent.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Oracles.DirectoryContent (
+    getDirectoryContent, directoryContentOracle, Exclude(..), ExcludeNot(..)
+    ) where
+
+import Base
+import System.Directory.Extra
+
+newtype DirectoryContent = DirectoryContent (Exclude, ExcludeNot, FilePath)
+    deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
+newtype Exclude = Exclude [FilePattern]
+    deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
+newtype ExcludeNot = ExcludeNot [FilePattern]
+    deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
+
+-- | Get the directory content. 'Exclude' and 'ExcludeNot' are a list of file
+-- patterns matched with '?=='.
+getDirectoryContent :: Exclude -> ExcludeNot -> FilePath -> Action [FilePath]
+getDirectoryContent exclude excludeNot dir =
+    askOracle $ DirectoryContent (exclude, excludeNot, dir)
+
+directoryContentOracle :: Rules ()
+directoryContentOracle = void $ addOracle oracle
+  where
+    oracle :: DirectoryContent -> Action [FilePath]
+    oracle (DirectoryContent (Exclude exclude, ExcludeNot excludeNot, dir)) =
+        liftIO $ filter test <$> listFilesInside (return . test) dir
+      where
+        test a = include' a || not (exclude' a)
+        exclude' a = any (?== a) exclude
+        include' a = any (?== a) excludeNot

--- a/src/Rules/Actions.hs
+++ b/src/Rules/Actions.hs
@@ -2,7 +2,7 @@ module Rules.Actions (
     build, buildWithCmdOptions, buildWithResources, copyFile, fixFile, moveFile,
     removeFile, copyDirectory, copyDirectoryContent, createDirectory,
     moveDirectory, removeDirectory, applyPatch, runBuilder, runBuilderWith,
-    makeExecutable, renderProgram, renderLibrary, Exclude(..), ExcludeNot(..)
+    makeExecutable, renderProgram, renderLibrary, Match(..)
     ) where
 
 import qualified System.Directory.Extra as IO
@@ -129,12 +129,11 @@ copyDirectory source target = do
     quietly $ cmd cmdEcho ["cp", "-r", source, target]
 
 -- | Copy the content of the source directory into the target directory.
--- 'Exclude' and 'ExcludeNot' are a list of file patterns matched with '?=='.
 -- The copied content is tracked.
-copyDirectoryContent :: Exclude -> ExcludeNot -> FilePath -> FilePath -> Action ()
-copyDirectoryContent exclude excludeNot source target = do
+copyDirectoryContent :: Match -> FilePath -> FilePath -> Action ()
+copyDirectoryContent expr source target = do
     putProgressInfo $ renderAction "Copy directory content" source target
-    getDirectoryContent exclude excludeNot source >>= mapM_ cp
+    getDirectoryContent expr source >>= mapM_ cp
   where
     cp a = do
         createDirectory $ dropFileName $ target' a

--- a/src/Rules/Actions.hs
+++ b/src/Rules/Actions.hs
@@ -5,10 +5,9 @@ module Rules.Actions (
     makeExecutable, renderProgram, renderLibrary
     ) where
 
-import qualified System.Directory       as IO
+import qualified System.Directory.Extra as IO
 import qualified System.IO              as IO
 import qualified Control.Exception.Base as IO
-import qualified System.Directory.Extra as X
 
 import Base
 import CmdLineFlag
@@ -133,7 +132,7 @@ copyDirectory source target = do
 copyDirectoryContent :: (FilePath -> IO Bool) -> FilePath -> FilePath -> Action ()
 copyDirectoryContent test source target = do
     putProgressInfo $ renderAction "Copy directory" source target
-    liftIO $ X.listFilesInside test' source >>= mapM_ cp
+    liftIO $ IO.listFilesInside test' source >>= mapM_ cp
   where
     target' a = target -/- fromJust (stripPrefix source a)
     test' a = ifM (test a) (mkdir a >> return True) (return False)

--- a/src/Rules/Actions.hs
+++ b/src/Rules/Actions.hs
@@ -165,8 +165,7 @@ applyPatch dir patch = do
     quietly $ cmd Shell cmdEcho [Cwd dir] [path, "-p0 <", patch]
 
 runBuilder :: Builder -> [String] -> Action ()
-runBuilder =
-    runBuilderWith []
+runBuilder = runBuilderWith []
 
 runBuilderWith :: [CmdOption] -> Builder -> [String] -> Action ()
 runBuilderWith options builder args = do

--- a/src/Rules/Oracles.hs
+++ b/src/Rules/Oracles.hs
@@ -4,6 +4,7 @@ import Base
 import qualified Oracles.ArgsHash
 import qualified Oracles.Config
 import qualified Oracles.Dependencies
+import qualified Oracles.DirectoryContent
 import qualified Oracles.LookupInPath
 import qualified Oracles.ModuleFiles
 import qualified Oracles.PackageData
@@ -15,6 +16,7 @@ oracleRules = do
     Oracles.ArgsHash.argsHashOracle
     Oracles.Config.configOracle
     Oracles.Dependencies.dependenciesOracles
+    Oracles.DirectoryContent.directoryContentOracle
     Oracles.LookupInPath.lookupInPathOracle
     Oracles.ModuleFiles.moduleFilesOracle
     Oracles.PackageData.packageDataOracle


### PR DESCRIPTION
These new functions will be helpful when implementing the 'sdist' and
'install' rules.