### PR TITLE
Change the stack configuration to use the local Cabal lib

### DIFF
--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -120,7 +120,7 @@ executable hadrian
                        , ScopedTypeVariables
     build-depends:       base >= 4.8 && < 5
                        , ansi-terminal        == 0.6.*
-                       , Cabal                == 1.22.* || == 1.24.*
+                       , Cabal                == 1.22.* || == 1.24.* || == 1.25.*
                        , containers           == 0.5.*
                        , directory            == 1.2.*
                        , extra                >= 1.4.7

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ resolver: lts-5.17
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
+- '../libraries/Cabal/Cabal'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:


### PR DESCRIPTION
This seems to fix using `build.stack.sh` for me (I haven't finished building the whole GHC yet though).

I'm also not sure about the version bound on `Cabal` in the `hadrian.cabal`. What do you think?