### PR TITLE
Fix inability to find gmp.h when building concurrently

### DIFF
--- a/src/Rules/Dependencies.hs
+++ b/src/Rules/Dependencies.hs
@@ -11,6 +11,8 @@ import Rules.Actions
 import Settings.Paths
 import Target
 import UserSettings
+import GHC
+
 
 buildPackageDependencies :: [(Resource, Int)] -> Context -> Rules ()
 buildPackageDependencies rs context@Context {..} =
@@ -20,6 +22,7 @@ buildPackageDependencies rs context@Context {..} =
         fmap (path ++)
             [ "//*.c.deps", "//*.cmm.deps", "//*.S.deps" ] |%> \out -> do
                 let src = dep2src context out
+                when (package == integerGmp) (need [gmpLibraryH])
                 need [src]
                 build $ Target context (Cc FindDependencies stage) [src] [out]
 


### PR DESCRIPTION
There were situations when building concurrently when we would
request `gmp.h` before it had been built (or copied).

This was occuring when we generated the list of dependents for
the c files in the `integer-gmp` folder. Thus, when generating the
dependents for this library we now require `gmp.h`.