### PR TITLE
Use GCC's `-MM`/`-MG` to find missing dependencies

### DIFF
--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -21,7 +21,8 @@ import Stage
 -- 3) Linking object files & static libraries into an executable.
 -- We have CcMode for CC and GhcMode for GHC.
 
-data CcMode = CompileC | FindCDependencies
+-- TODO: Consider merging FindCDependencies and FindMissingInclude
+data CcMode = CompileC | FindCDependencies | FindMissingInclude
     deriving (Eq, Generic, Show)
 
 data GhcMode = CompileHs | FindHsDependencies | LinkHs

--- a/src/Settings/Builders/Cc.hs
+++ b/src/Settings/Builders/Cc.hs
@@ -26,7 +26,18 @@ ccBuilderArgs = mconcat
                 , arg $ dropExtension output -<.> "o"
                 , arg "-x"
                 , arg "c"
-                , arg =<< getInput ] ]
+                , arg =<< getInput ]
+
+    , builder (Cc FindMissingInclude) ? do
+        mconcat [ arg "-E"
+                , arg "-MM"
+                , arg "-MG"
+                , commonCcArgs
+                , arg "-MF"
+                , arg =<< getOutput
+                , arg =<< getInput
+                ]
+    ]
 
 commonCcArgs :: Args
 commonCcArgs = mconcat [ append =<< getPkgDataList CcArgs


### PR DESCRIPTION
So this is probably not ready to be merged, but I wanted to discuss a few things :-)

- I'm not sure what we could clean up - I'm planning to have a look at the places that use the current lists of generated files and see whether we can remove some of the explicit calls to `need` in favor of this approach. Ideas are welcome!

- It seems that applying the same trick to `.hs` files might be a bit more complicated - we can try to tell GCC to treat it just as a `.c` or `.h` file and stop at pre-processing, but things like `MIN_VERSION_*` still cause it to die with an error (since they're not defined).

- Does GHC actually have a case where a generated file `#include`s another generated file? (if not we could just go with a bit more brute-force approach of grepping the source?).

- Finally, I'm wondering if we should create a cache/oracle for this information - it's pretty easy to have the same file being analyzed multiple times just by the virtue of being a dependency for many other `.c` files.