### PR TITLE
Bump stack to lts-6.12 and remove extra pkg from extra-deps

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.17
+resolver: lts-6.12
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -10,7 +10,6 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- extra-1.4.7
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Apart from simplifying `stack.yaml`, removing explicit `extra` will also make the upgrade to GHC 8.0 easier (once stackage LTS moves to it).
`extra` is no longer necessary since it's included on stackage:  https://www.stackage.org/lts-6.12/package/extra-1.4.10

I've tested this by building GHC locally.