### PR TITLE
Build mkUserGuidePart with stage-0

### DIFF
--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -98,11 +98,14 @@ isOptional = \case
     Objdump  -> True
     _        -> False
 
--- TODO: Get rid of fromJust.
 -- | Determine the location of a 'Builder'.
 builderPath :: Builder -> Action FilePath
 builderPath builder = case builderProvenance builder of
-    Just context -> return . fromJust $ programPath context
+    Just context
+      | Just path <- programPath context -> return path
+      | otherwise                        ->
+        error $ "Cannot determine builderPath for " ++ show builder
+             ++ " in context " ++ show context
     Nothing -> case builder of
         Alex          -> fromKey "alex"
         Ar            -> fromKey "ar"

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -104,6 +104,7 @@ builderPath builder = case builderProvenance builder of
     Just context
       | Just path <- programPath context -> return path
       | otherwise                        ->
+        -- TODO: Make builderPath total.
         error $ "Cannot determine builderPath for " ++ show builder
              ++ " in context " ++ show context
     Nothing -> case builder of

--- a/src/GHC.hs
+++ b/src/GHC.hs
@@ -102,7 +102,10 @@ ghcSplit = "inplace/lib/bin/ghc-split"
 programPath :: Context -> Maybe FilePath
 programPath context@Context {..}
     | package == ghc = Just . inplaceProgram $ "ghc-stage" ++ show (fromEnum stage + 1)
-    | package `elem` [checkApiAnnotations, ghcTags, haddock, mkUserGuidePart] =
+    | package `elem` [mkUserGuidePart] =
+        case stage of Stage0 -> Just . inplaceProgram $ pkgNameString package
+                      _      -> Nothing
+    | package `elem` [checkApiAnnotations, ghcTags, haddock] =
         case stage of Stage2 -> Just . inplaceProgram $ pkgNameString package
                       _      -> Nothing
     | package `elem` [touchy, unlit] = case stage of

--- a/src/Rules.hs
+++ b/src/Rules.hs
@@ -49,7 +49,13 @@ topLevelTargets = do
                     docs <- interpretInContext context $ buildHaddock flavour
                     need $ libs ++ [ pkgHaddockFile context | docs && stage == Stage1 ]
                 else do -- otherwise build a program
-                    need [ fromJust $ programPath context ] -- TODO: drop fromJust
+                    need [ getProgramPath context ]
+  where
+    getProgramPath context =
+        case programPath context of
+          Nothing   -> error $ "topLevelTargets: Can't determine program path for context "
+                            ++ show context
+          Just path -> path
 
 packageRules :: Rules ()
 packageRules = do

--- a/src/Settings/Default.hs
+++ b/src/Settings/Default.hs
@@ -108,7 +108,7 @@ packagesStage0 = mconcat
              , ghcPkg, hsc2hs, hoopl, hpc, templateHaskell, transformers ]
     -- the stage0 predicate makes sure these packages are built only in Stage0
     , stage0 ? append [ deriveConstants, dllSplit, genapply, genprimopcode
-                      , hp2ps, unlit ]
+                      , hp2ps, unlit, mkUserGuidePart ]
     , stage0 ? windowsHost ? append [touchy]
     , notM windowsHost ? notM iosHost ? append [terminfo] ]
 
@@ -127,7 +127,7 @@ packagesStage1 = mconcat
 -- in Stage2 and Stage3. Can we check this in compile time?
 packagesStage2 :: Packages
 packagesStage2 = mconcat
-    [ append [checkApiAnnotations, ghcTags, mkUserGuidePart]
+    [ append [checkApiAnnotations, ghcTags ]
     , buildHaddock flavour ? append [haddock] ]
 
 -- TODO: What about profilingDynamic way? Do we need platformSupportsSharedLibs?


### PR DESCRIPTION
This addresses GHC #12619, allowing the users guide to be built with only the stage 0 compiler.

Also eliminates some `fromJust`s that I encountered when putting this together.