### PR TITLE
Parallelize stage0 build

### DIFF
--- a/src/Settings/Default.hs
+++ b/src/Settings/Default.hs
@@ -262,6 +262,13 @@ disableWarningArgsLibs = do
     [ notStage0 ? arg "-Wno-deprecated-flags"
     , stage Stage0 ? arg "-fno-warn-deprecated-flags"]
 
+-- | Perform stage0 build (which uses a monolithic @ghc --make@ invocation)
+-- with @-j@.
+parallelStage0BuildArgs :: Args
+parallelStage0BuildArgs = do
+    threads <- shakeThreads <$> lift getShakeOptions
+    stage Stage0 ? builder Ghc ? arg ("-j"++show threads)
+
 -- TODO: Disable warnings for Windows specifics
 
 -- | All 'Package'-dependent command line arguments.
@@ -279,4 +286,5 @@ defaultPackageArgs = mconcat
     , runGhcPackageArgs
     , disableWarningArgsStage0
     , disableWarningArgsStage1
-    , disableWarningArgsLibs ]
+    , disableWarningArgsLibs
+    , parallelStage0BuildArgs ]


### PR DESCRIPTION
This eliminates a rather significant duration of serial compilation from the
build.

I'm still not 100% certain we want to do this by default, but I thought it would be good to put it up for discussion.