### PR TITLE
Use correct ar for host/target

### DIFF
--- a/cfg/system.config.in
+++ b/cfg/system.config.in
@@ -16,6 +16,7 @@ make           = @MakeCmd@
 nm             = @NmCmd@
 objdump        = @ObjdumpCmd@
 ranlib         = @REAL_RANLIB_CMD@
+system-ar      = @AR_STAGE0@
 system-cc      = @CC_STAGE0@
 system-ghc     = @WithGhc@
 system-ghc-pkg = @GhcPkgCmd@

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -28,7 +28,7 @@ data GhcPkgMode = Init | Update deriving (Eq, Generic, Show)
 -- @GhcPkg Stage0@ is the bootstrapping @GhcPkg@.
 -- @GhcPkg Stage1@ is the one built in Stage0.
 data Builder = Alex
-             | Ar
+             | Ar Stage
              | DeriveConstants
              | Cc CcMode Stage
              | Configure FilePath

--- a/src/Oracles/Path.hs
+++ b/src/Oracles/Path.hs
@@ -24,7 +24,8 @@ getTopDirectory = lift topDirectory
 systemBuilderPath :: Builder -> Action FilePath
 systemBuilderPath builder = case builder of
     Alex            -> fromKey "alex"
-    Ar              -> fromKey "ar"
+    Ar Stage0       -> fromKey "system-ar"
+    Ar _            -> fromKey "ar"
     Cc  _  Stage0   -> fromKey "system-cc"
     Cc  _  _        -> fromKey "cc"
     -- We can't ask configure for the path to configure!

--- a/src/Rules/Gmp.hs
+++ b/src/Rules/Gmp.hs
@@ -25,7 +25,7 @@ gmpMakefile = gmpBuildPath -/- "Makefile"
 
 configureEnvironment :: Action [CmdOption]
 configureEnvironment = sequence [ builderEnvironment "CC" $ Cc CompileC Stage1
-                                , builderEnvironment "AR" Ar
+                                , builderEnvironment "AR" (Ar Stage1)
                                 , builderEnvironment "NM" Nm ]
 
 gmpRules :: Rules ()
@@ -43,7 +43,7 @@ gmpRules = do
             putBuild "| No GMP library/framework detected; in tree GMP will be built"
             need [gmpLibrary]
             createDirectory gmpObjects
-            build $ Target gmpContext Ar [gmpLibrary] [gmpObjects]
+            build $ Target gmpContext (Ar Stage1) [gmpLibrary] [gmpObjects]
             copyFile (gmpBuildPath -/- "gmp.h") header
             copyFile (gmpBuildPath -/- "gmp.h") gmpLibraryInTreeH
 

--- a/src/Rules/Libffi.hs
+++ b/src/Rules/Libffi.hs
@@ -31,7 +31,7 @@ configureEnvironment = do
     sequence [ builderEnvironment "CC" $ Cc CompileC Stage1
              , builderEnvironment "CXX" $ Cc CompileC Stage1
              , builderEnvironment "LD" Ld
-             , builderEnvironment "AR" Ar
+             , builderEnvironment "AR" (Ar Stage1)
              , builderEnvironment "NM" Nm
              , builderEnvironment "RANLIB" Ranlib
              , return . AddEnv  "CFLAGS" $ unwords  cFlags ++ " -w"

--- a/src/Rules/Library.hs
+++ b/src/Rules/Library.hs
@@ -72,8 +72,8 @@ buildPackageLibrary context@Context {..} = do
 
         asuf <- libsuf way
         let isLib0 = ("//*-0" ++ asuf) ?== a
-        if isLib0 then build $ Target context Ar []   [a] -- TODO: Scan for dlls
-                  else build $ Target context Ar objs [a]
+        if isLib0 then build $ Target context (Ar stage) []   [a] -- TODO: Scan for dlls
+                  else build $ Target context (Ar stage) objs [a]
 
         synopsis <- interpretInContext context $ getPkgData Synopsis
         unless isLib0 . putSuccess $ renderLibrary

--- a/src/Settings/Builders/GhcCabal.hs
+++ b/src/Settings/Builders/GhcCabal.hs
@@ -25,7 +25,7 @@ ghcCabalBuilderArgs = builder GhcCabal ? do
             , packageConstraints
             , withStaged $ Cc CompileC
             , notStage0 ? with Ld
-            , with Ar
+            , withStaged Ar
             , with Alex
             , with Happy
             , verbosity < Chatty ? append [ "-v0", "--configure-option=--quiet"
@@ -91,7 +91,7 @@ cppArgs = arg $ "-I" ++ generatedPath
 
 withBuilderKey :: Builder -> String
 withBuilderKey b = case b of
-    Ar         -> "--with-ar="
+    Ar _       -> "--with-ar="
     Ld         -> "--with-ld="
     Cc  _ _    -> "--with-gcc="
     Ghc _ _    -> "--with-ghc="

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -53,7 +53,7 @@ customBuild rs opts target@Target {..} = do
     withResources rs $ do
         putInfo target
         quietlyUnlessVerbose $ case builder of
-            Ar -> do
+            Ar _ -> do
                 output <- interpret target getOutput
                 if "//*.a" ?== output
                 then arCmd path argList


### PR DESCRIPTION
Previously we would always use the ar of the target; this is incorrect.

Fixes #350.