### PR TITLE
Don't optimize cabal stage0 build

### DIFF
--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -91,6 +91,7 @@ executable hadrian
                        , Settings.Flavours.Quick
                        , Settings.Flavours.Quickest
                        , Settings.Packages.Base
+                       , Settings.Packages.Cabal
                        , Settings.Packages.Compiler
                        , Settings.Packages.Ghc
                        , Settings.Packages.GhcCabal

--- a/src/Settings/Default.hs
+++ b/src/Settings/Default.hs
@@ -30,6 +30,7 @@ import Settings.Builders.Ld
 import Settings.Builders.Make
 import Settings.Builders.Tar
 import Settings.Packages.Base
+import Settings.Packages.Cabal
 import Settings.Packages.Compiler
 import Settings.Packages.Ghc
 import Settings.Packages.GhcCabal
@@ -268,6 +269,7 @@ disableWarningArgsLibs = do
 defaultPackageArgs :: Args
 defaultPackageArgs = mconcat
     [ basePackageArgs
+    , cabalPackageArgs
     , compilerPackageArgs
     , ghcPackageArgs
     , ghcCabalPackageArgs
@@ -279,4 +281,5 @@ defaultPackageArgs = mconcat
     , runGhcPackageArgs
     , disableWarningArgsStage0
     , disableWarningArgsStage1
-    , disableWarningArgsLibs ]
+    , disableWarningArgsLibs
+    ]

--- a/src/Settings/Packages/Cabal.hs
+++ b/src/Settings/Packages/Cabal.hs
@@ -1,0 +1,11 @@
+module Settings.Packages.Cabal where
+
+import GHC
+import Predicate
+
+cabalPackageArgs :: Args
+cabalPackageArgs = package cabal ? do
+    -- Cabal is a rather large library and quite slow to compile. Moreover, we
+    -- build it for stage0 only so we can link ghc-pkg against it, so there is
+    -- little reason to spend the effort to optimize it.
+    stage Stage0 ? builder Ghc ? append [ "-O0" ]


### PR DESCRIPTION
The performance of the stage0 `Cabal` build is not critical. I am guessing that this will help bring down the stage0 compilation time, although I have yet to quantify this.