### PR TITLE
Drop language in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: true
-language: haskell
 matrix:
     include:
         - os: linux


### PR DESCRIPTION
The latest build failure https://travis-ci.org/snowleopard/hadrian/jobs/255299317 is probably caused by this. Adding this line makes the build status list clearer since there is not a non-relavent "Ruby", but I should anticipate that it might introduce some unwanted effects.