### PR TITLE
Disable parallel garbage collection

### DIFF
--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -133,5 +133,11 @@ executable hadrian
                        , happy >= 1.19.4
     ghc-options:         -Wall
                          -fno-warn-name-shadowing
-                         -rtsopts -with-rtsopts=-I0
+                         -rtsopts
+                         -- Disable idle GC to avoid redundant GCs while waiting
+                         -- for external processes
+                         -with-rtsopts=-I0
+                         -- Don't use parallel GC as the synchronization time tends to eat any
+                         -- benefit.
+                         -with-rtsopts=-qg0
                          -threaded


### PR DESCRIPTION
This brings productivity from roughly 40% to 95%. With parallel GC we generally
spend much of our time synchronizing between the GC threads and relatively
little time doing productive work since we spend most of our time waiting for external processes and generate relatively little garbage.