### PR TITLE
.bat file tidy up plus shake-0.16 compatibility

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal
 cd %~dp0
 mkdir bin 2> nul
 

--- a/build.bat
+++ b/build.bat
@@ -1,31 +1,32 @@
-@cd %~dp0
-@mkdir bin 2> nul
+@echo off
+cd %~dp0
+mkdir bin 2> nul
 
-@set ghcArgs=--make                     ^
-             -Wall                      ^
-             -fno-warn-name-shadowing   ^
-             -XRecordWildCards          ^
-             src\Main.hs                ^
-             -threaded                  ^
-             -isrc                      ^
-             -i..\libraries\Cabal\Cabal ^
-             -rtsopts                   ^
-             -with-rtsopts=-I0          ^
-             -outputdir=bin             ^
-             -j                         ^
-             -O                         ^
-             -o bin\hadrian
+set ghcArgs=--make                     ^
+            -Wall                      ^
+            -fno-warn-name-shadowing   ^
+            -XRecordWildCards          ^
+            src\Main.hs                ^
+            -threaded                  ^
+            -isrc                      ^
+            -i..\libraries\Cabal\Cabal ^
+            -rtsopts                   ^
+            -with-rtsopts=-I0          ^
+            -outputdir=bin             ^
+            -j                         ^
+            -O                         ^
+            -o bin\hadrian
 
-@set hadrianArgs=--lint      ^
-                 --directory ^
-                 ".."        ^
-                 %*
+set hadrianArgs=--lint      ^
+                --directory ^
+                ".."        ^
+                %*
 
 
-@ghc %ghcArgs%
+ghc %ghcArgs%
 
-@if %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
+if %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 
-@rem Unset GHC_PACKAGE_PATH variable, as otherwise ghc-cabal complains
-@set GHC_PACKAGE_PATH=
-@bin\hadrian %hadrianArgs%
+rem Unset GHC_PACKAGE_PATH variable, as otherwise ghc-cabal complains
+set GHC_PACKAGE_PATH=
+bin\hadrian %hadrianArgs%

--- a/build.stack.bat
+++ b/build.stack.bat
@@ -1,9 +1,10 @@
-@rem Change the current directory to the one containing this script
-@cd %~dp0
+@echo off
+rem Change the current directory to the one containing this script
+cd %~dp0
 
-@rem Build Hadrian and dependencies and exit the script if the build failed
-@stack build
-@if %errorlevel% neq 0 exit /B %errorlevel%
+rem Build Hadrian and dependencies and exit the script if the build failed
+stack build
+if %errorlevel% neq 0 exit /B %errorlevel%
 
-@rem Run Hadrian in GHC top directory forwarding additional user arguments
-@stack exec hadrian -- --lint --directory ".." %*
+rem Run Hadrian in GHC top directory forwarding additional user arguments
+stack exec hadrian -- --lint --directory ".." %*

--- a/build.stack.bat
+++ b/build.stack.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal
 rem Change the current directory to the one containing this script
 cd %~dp0
 

--- a/src/Hadrian/Oracles/ArgsHash.hs
+++ b/src/Hadrian/Oracles/ArgsHash.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 module Hadrian.Oracles.ArgsHash (
     TrackArgument, trackAllArguments, trackArgsHash, argsHashOracle
     ) where
@@ -8,6 +9,7 @@ import Development.Shake.Classes
 
 import Hadrian.Expression hiding (inputs, outputs)
 import Hadrian.Target
+import Hadrian.Utilities
 
 -- | 'TrackArgument' is used to specify the arguments that should be tracked by
 -- the @ArgsHash@ oracle. The safest option is to track all arguments, but some
@@ -38,6 +40,7 @@ trackArgsHash t = do
 
 newtype ArgsHash c b = ArgsHash (Target c b)
     deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
+type instance RuleResult (ArgsHash c b) = Int
 
 -- | This oracle stores per-target argument list hashes in the Shake database,
 -- allowing the user to track them between builds using 'trackArgsHash' queries.

--- a/src/Hadrian/Oracles/DirectoryContents.hs
+++ b/src/Hadrian/Oracles/DirectoryContents.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 module Hadrian.Oracles.DirectoryContents (
     directoryContents, copyDirectoryContents, directoryContentsOracle,
     Match (..), matches, matchAll
@@ -46,6 +47,7 @@ copyDirectoryContents expr source target = do
 
 newtype DirectoryContents = DirectoryContents (Match, FilePath)
     deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
+type instance RuleResult DirectoryContents = [FilePath]
 
 -- | This oracle answers 'directoryContents' queries and tracks the results.
 directoryContentsOracle :: Rules ()

--- a/src/Hadrian/Oracles/FileCache.hs
+++ b/src/Hadrian/Oracles/FileCache.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module     : Hadrian.Oracles.FileCache
@@ -22,6 +23,7 @@ import Hadrian.Utilities
 
 newtype FileCache = FileCache FilePath
     deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
+type instance RuleResult FileCache = String
 
 -- | Read a text file, caching and tracking the result. To read and track
 -- individual lines of the file, see "Hadrian.Oracles.KeyValue".

--- a/src/Hadrian/Oracles/KeyValue.hs
+++ b/src/Hadrian/Oracles/KeyValue.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 module Hadrian.Oracles.KeyValue (
     lookupValue, lookupValueOrEmpty, lookupValueOrError, lookupValues,
     lookupValuesOrEmpty, lookupValuesOrError, lookupDependencies, keyValueOracle
@@ -14,9 +15,11 @@ import Hadrian.Utilities
 
 newtype KeyValue = KeyValue (FilePath, String)
     deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
+type instance RuleResult KeyValue = Maybe String
 
 newtype KeyValues = KeyValues (FilePath, String)
     deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
+type instance RuleResult KeyValues = Maybe [String]
 
 -- | Lookup a value in a text file, tracking the result. Each line of the file
 -- is expected to have @key = value@ format.

--- a/src/Hadrian/Oracles/Path.hs
+++ b/src/Hadrian/Oracles/Path.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 module Hadrian.Oracles.Path (
     lookupInPath, bashPath, fixAbsolutePathOnWindows, pathOracle
     ) where
@@ -39,9 +40,11 @@ fixAbsolutePathOnWindows path = do
 
 newtype LookupInPath = LookupInPath String
     deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
+type instance RuleResult LookupInPath = String
 
 newtype WindowsPath = WindowsPath FilePath
     deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
+type instance RuleResult WindowsPath = String
 
 -- | Oracles for looking up paths. These are slow and require caching.
 pathOracle :: Rules ()

--- a/src/Hadrian/Utilities.hs
+++ b/src/Hadrian/Utilities.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 module Hadrian.Utilities (
     -- * List manipulation
     fromSingleton, replaceEq, minusOrd, intersectOrd, lookupAll,
@@ -23,6 +24,9 @@ module Hadrian.Utilities (
     SuccessColour (..), putSuccess, ProgressInfo (..),
     putProgressInfo, renderAction, renderProgram, renderLibrary, renderBox,
     renderUnicorn,
+
+    -- * Shake compatibility
+    RuleResult,
 
     -- * Miscellaneous
     (<&>), (%%>),
@@ -155,6 +159,9 @@ buildRoot = do
 (<&>) = flip fmap
 
 infixl 1 <&>
+
+-- | Introduced in shake-0.16, so use to make the rest of the code compatible
+type family RuleResult a
 
 -- | Given a 'FilePath' to a source file, return 'True' if it is generated.
 -- The current implementation simply assumes that a file is generated if it

--- a/src/Oracles/ModuleFiles.hs
+++ b/src/Oracles/ModuleFiles.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 module Oracles.ModuleFiles (
     decodeModule, encodeModule, findGenerator, hsSources, hsObjects, moduleFilesOracle
     ) where
@@ -11,9 +12,11 @@ import Oracles.PackageData
 
 newtype ModuleFiles = ModuleFiles (Stage, Package)
     deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
+type instance RuleResult ModuleFiles = [Maybe FilePath]
 
 newtype Generator = Generator (Stage, Package, FilePath)
     deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
+type instance RuleResult Generator = Maybe FilePath
 
 -- | We scan for the following Haskell source extensions when looking for module
 -- files. Note, we do not list "*.(l)hs-boot" files here, as they can never


### PR DESCRIPTION
Two things in the patch:

* I cleaned up the `.bat` files - more readable, don't change the directory in the calling shell.
* I added `RuleResult` instances for every oracle, which is required to compile with shake-0.16. I added a compat wrapper for now, but once the new version is released that can be removed.

This patch means the shake release is getting a lot closer.