### PR TITLE
Fix install rules by untracking copy files and use relative path

### DIFF
--- a/src/Hadrian/Oracles/DirectoryContents.hs
+++ b/src/Hadrian/Oracles/DirectoryContents.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
 module Hadrian.Oracles.DirectoryContents (
-    directoryContents, copyDirectoryContents, directoryContentsOracle,
+    directoryContents, copyDirectoryContents, directoryContentsOracle, copyDirectoryContentsUntracked,
     Match (..), matches, matchAll
     ) where
 
@@ -43,6 +43,14 @@ copyDirectoryContents :: Match -> FilePath -> FilePath -> Action ()
 copyDirectoryContents expr source target = do
     putProgressInfo =<< renderAction "Copy directory contents" source target
     let cp file = copyFile file $ target -/- makeRelative source file
+    mapM_ cp =<< directoryContents expr source
+
+-- | Copy the contents of the source directory that matches a given 'Match'
+-- expression into the target directory. The copied contents is untracked.
+copyDirectoryContentsUntracked :: Match -> FilePath -> FilePath -> Action ()
+copyDirectoryContentsUntracked expr source target = do
+    putProgressInfo =<< renderAction "Copy directory contents (untracked)" source target
+    let cp file = copyFileUntracked file $ target -/- makeRelative source file
     mapM_ cp =<< directoryContents expr source
 
 newtype DirectoryContents = DirectoryContents (Match, FilePath)

--- a/src/Rules/Install.hs
+++ b/src/Rules/Install.hs
@@ -186,7 +186,9 @@ installPackages = do
             withLatestBuildStage pkg $ \stage -> do
                 let context = vanillaContext stage pkg
                 top <- topDirectory
-                installDistDir <- (top -/-) <$> buildPath context
+                installDistDir <- buildPath context
+                let absInstallDistDir = top -/- installDistDir
+
                 need =<< packageTargets stage pkg
                 docDir <- installDocDir
                 ghclibDir <- installGhcLibDir
@@ -203,7 +205,7 @@ installPackages = do
                 need [cabalFile, pkgConf] -- TODO: check if need pkgConf
 
                 -- HACK (#318): copy stuff back to the place favored by ghc-cabal
-                quietly $ copyDirectoryContents (Not excluded)
+                quietly $ copyDirectoryContentsUntracked (Not excluded)
                     installDistDir (installDistDir -/- "build")
 
                 whenM (isSpecified HsColour) $
@@ -212,7 +214,7 @@ installPackages = do
                 pref <- setting InstallPrefix
                 unit $ cmd ghcCabalInplace [ "copy"
                                            , pkgPath pkg
-                                           , installDistDir
+                                           , absInstallDistDir
                                            , strip
                                            , destDir
                                            , pref


### PR DESCRIPTION
Fix #394 