### PR TITLE
Install rule: copy gmp header

### DIFF
--- a/src/Rules/Install.hs
+++ b/src/Rules/Install.hs
@@ -185,6 +185,9 @@ installPackages = do
 
     installLibPkgs <- topsortPackages (filter isLibrary activePackages)
 
+    -- TODO (izgzhen): figure out what is the root cause of the missing ghc-gmp.h error
+    copyFile (pkgPath integerGmp -/- "gmp/ghc-gmp.h") (pkgPath integerGmp -/- "ghc-gmp.h")
+
     forM_ installLibPkgs $ \pkg -> do
         when (isLibrary pkg) $
             withLatestBuildStage pkg $ \stage -> do


### PR DESCRIPTION
Fix:

```
Error when running Shake build system:
* install
user error (Development.Shake.cmd, system command failed
Command: inplace/bin/ghc-cabal copy libraries/integer-gmp /tmp/tmpME8BvT/ghc/_build/stage1/libraries/integer-gmp strip /tmp/tmpME8BvT /usr/local /usr/local/lib/ghc-8.3.20170821 /usr/local/share/doc/ghc-8.3.20170821/html/libraries 'v p dyn'
Exit code: 1
Stderr:
ghc-cabal: can't find include file ghc-gmp.h
)
```

http://hadrian-status-dev.zhenzhang.me/logs/2017-08-22T06%3A48%3A13.572819%25default%255631.28768206%25failure.err.log