### PR TITLE
Remove unnecessary use of -DGENERICS flag

### DIFF
--- a/src/Settings/Packages/GhcCabal.hs
+++ b/src/Settings/Packages/GhcCabal.hs
@@ -18,7 +18,6 @@ ghcCabalPackageArgs = stage0 ? package ghcCabal ? builder Ghc ? do
         , arg ("-DCABAL_VERSION=" ++ replace "." "," cabalVersion)
         , arg "-DBOOTSTRAPPING"
         , arg "-DMIN_VERSION_binary_0_8_0"
-        , arg "-DGENERICS"
         , arg "-optP-include"
         , arg $ "-optP" ++ pkgPath ghcCabal -/- "cabal_macros_boot.h"
         , arg "-ilibraries/Cabal/Cabal"


### PR DESCRIPTION
This mirrors a change made to GHC in http://git.haskell.org/ghc.git/commit/a28a55211d6fb8d3182b0a9e47656ff9ca8a3766.