### PR TITLE
Implement documentation building

### DIFF
--- a/cfg/system.config.in
+++ b/cfg/system.config.in
@@ -10,12 +10,12 @@ ar             = @ArCmd@
 cc             = @CC@
 happy          = @HappyCmd@
 hs-cpp         = @HaskellCPPCmd@
-hscolour       = @HSCOLOUR@
 ld             = @LdCmd@
 make           = @MakeCmd@
 nm             = @NmCmd@
 objdump        = @ObjdumpCmd@
 ranlib         = @REAL_RANLIB_CMD@
+sphinx-build   = @SPHINXBUILD@
 system-ar      = @AR_STAGE0@
 system-cc      = @CC_STAGE0@
 system-ghc     = @WithGhc@
@@ -24,6 +24,7 @@ tar            = @TarCmd@
 patch          = @PatchCmd@
 perl           = @PerlCmd@
 ln-s           = @LN_S@
+xelatex        = @XELATEX@
 
 # Information about builders:
 #============================

--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -77,7 +77,9 @@ executable hadrian
                        , Settings.Builders.HsCpp
                        , Settings.Builders.Ld
                        , Settings.Builders.Make
+                       , Settings.Builders.Sphinx
                        , Settings.Builders.Tar
+                       , Settings.Builders.Xelatex
                        , Settings.Default
                        , Settings.Flavours.Development
                        , Settings.Flavours.Performance

--- a/src/Context.hs
+++ b/src/Context.hs
@@ -109,7 +109,7 @@ pkgSetupConfigFile context = do
 -- | Path to the haddock file of a given 'Context', e.g.:
 -- @_build/stage1/libraries/array/doc/html/array/array.haddock@.
 pkgHaddockFile :: Context -> Action FilePath
-pkgHaddockFile context@Context {..} = do
+pkgHaddockFile Context {..} = do
     root <- buildRoot
     let name = pkgName package
     return $ root -/- "docs/html/libraries" -/- name -/- name <.> "haddock"

--- a/src/Context.hs
+++ b/src/Context.hs
@@ -110,9 +110,9 @@ pkgSetupConfigFile context = do
 -- @_build/stage1/libraries/array/doc/html/array/array.haddock@.
 pkgHaddockFile :: Context -> Action FilePath
 pkgHaddockFile context@Context {..} = do
-    path <- buildPath context
+    root <- buildRoot
     let name = pkgName package
-    return $ path -/- "doc/html" -/- name -/- name <.> "haddock"
+    return $ root -/- "docs/html/libraries" -/- name -/- name <.> "haddock"
 
 -- | Path to the library file of a given 'Context', e.g.:
 -- @_build/stage1/libraries/array/build/libHSarray-0.5.1.0.a@.

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -9,6 +9,7 @@ import qualified CommandLine
 import qualified Environment
 import qualified Rules
 import qualified Rules.Clean
+import qualified Rules.Documentation
 import qualified Rules.Install
 import qualified Rules.SourceDist
 import qualified Rules.Selftest
@@ -38,6 +39,7 @@ main = do
         rules :: Rules ()
         rules = do
             Rules.buildRules
+            Rules.Documentation.documentationRules
             Rules.Clean.cleanRules
             Rules.Install.installRules
             Rules.oracleRules

--- a/src/Rules/Documentation.hs
+++ b/src/Rules/Documentation.hs
@@ -1,4 +1,4 @@
-module Rules.Documentation (buildPackageDocumentation, haddockDependencies) where
+module Rules.Documentation (buildPackageDocumentation, documentationRules, haddockDependencies) where
 
 import Base
 import Context
@@ -9,6 +9,81 @@ import Oracles.PackageData
 import Settings
 import Target
 import Utilities
+
+docPackage :: Package
+docPackage = hsLibrary "Documentation" "docs"
+
+-- | Build all documentation
+documentationRules :: Rules ()
+documentationRules = do
+    buildHtmlDocumentation
+    buildPdfDocumentation
+    buildDocumentationArchives
+    "docs" ~> do
+        root <- buildRoot
+        -- Archives `need` the associated html
+        let archives = map pathArchive docPaths
+            pdfs = map pathPdf $ drop 1 docPaths
+        need $ map (root -/-) $ archives ++ pdfs
+
+docPaths :: [FilePath]
+docPaths = [ "libraries", "users_guide", "Haddock" ]
+
+docRoot :: FilePath
+docRoot = "docs"
+
+htmlRoot :: FilePath
+htmlRoot = docRoot -/- "html"
+
+pdfRoot :: FilePath
+pdfRoot = docRoot -/- "pdfs"
+
+archiveRoot :: FilePath
+archiveRoot = docRoot -/- "archives"
+
+pathPdf :: FilePath -> FilePath
+pathPdf path = pdfRoot -/- path <.> ".pdf"
+
+pathIndex :: FilePath -> FilePath
+pathIndex path = htmlRoot -/- path -/- "index.html"
+
+pathLibIndex :: FilePath -> FilePath
+pathLibIndex path = htmlRoot -/- "libraries" -/- path -/- "index.html"
+
+pathArchive :: FilePath -> FilePath
+pathArchive path = archiveRoot -/- path <.> "html.tar.xz"
+
+pathPath :: FilePath -> FilePath
+pathPath "users_guide" = "docs/users_guide"
+pathPath "Haddock" = "utils/haddock/doc"
+pathPath _ = "lol"
+
+----------------------------------------------------------------------
+-- HTML
+
+-- | Build all HTML documentation
+buildHtmlDocumentation :: Rules ()
+buildHtmlDocumentation = do
+    mapM_ buildSphinxHtml $ drop 1 docPaths
+    buildLibraryDocumentation
+    "//html/index.html" %> \file -> do
+        root <- buildRoot
+        need $ map ((root -/-) . pathIndex) docPaths
+        copyFileUntracked "docs/index.html" file
+
+-----------------------------
+-- Sphinx
+
+-- | Compile a Sphinx ReStructured Text package to HTML
+buildSphinxHtml :: FilePath -> Rules ()
+buildSphinxHtml path = do
+    "//" ++ htmlRoot -/- path -/- "index.html" %> \file -> do
+        let dest = takeDirectory file
+            context = vanillaContext Stage0 docPackage
+        build $ target context (Sphinx Html) [pathPath path] [dest]
+
+-----------------------------
+-- Haddock
 
 haddockHtmlLib :: FilePath
 haddockHtmlLib = "inplace/lib/html/haddock-util.js"
@@ -25,9 +100,17 @@ haddockDependencies context = do
 -- files in the Shake database seems fragile and unnecessary.
 buildPackageDocumentation :: Context -> Rules ()
 buildPackageDocumentation context@Context {..} = when (stage == Stage1) $ do
-    "//" ++ contextDir context ++ "//*.haddock" %> \file -> do
-        srcs     <- hsSources context
+
+    -- Js and Css files for haddock output
+    when (package == haddock) $ haddockHtmlLib %> \_ -> do
+        let dir = takeDirectory haddockHtmlLib
+        liftIO $ removeFiles dir ["//*"]
+        copyDirectory "utils/haddock/haddock-api/resources/html" dir
+
+    -- Per-package haddocks
+    "//" ++ pkgName package <.> "haddock" %> \file -> do
         haddocks <- haddockDependencies context
+        srcs <- hsSources context
         need $ srcs ++ haddocks ++ [haddockHtmlLib]
 
         -- Build Haddock documentation
@@ -36,12 +119,72 @@ buildPackageDocumentation context@Context {..} = when (stage == Stage1) $ do
         let haddockWay = if dynamicPrograms then dynamic else vanilla
         build $ target (context {way = haddockWay}) Haddock srcs [file]
 
-    when (package == haddock) $ haddockHtmlLib %> \_ -> do
-        let dir = takeDirectory haddockHtmlLib
-        liftIO $ removeFiles dir ["//*"]
-        copyDirectory "utils/haddock/haddock-api/resources/html" dir
+-- | Build the haddocks for GHC's libraries
+buildLibraryDocumentation :: Rules ()
+buildLibraryDocumentation = do
+    "//" ++ htmlRoot -/- "libraries/index.html" %> \file -> do
+        haddocks <- allHaddocks
+        need haddocks
+        let libDocs = filter (\x -> takeFileName x /= "ghc.haddock") haddocks
+        let iface haddock = "--read-interface="
+                            ++ (takeFileName . takeDirectory) haddock ++ ","
+                            ++ haddock
+        runBuilder Haddock ([ "--gen-index"
+                            , "--gen-contents"
+                            , "-o", takeDirectory file
+                            , "-t", "Haskell Hierarchical Libraries"
+                            , "-p", "libraries/prologue.txt" ]
+                            ++ map iface libDocs)
+                           [] [file]
+  where
+    allHaddocks = do
+        pkgs <- stagePackages Stage1
+        sequence [ pkgHaddockFile $ vanillaContext Stage1 pkg
+                 | pkg <- pkgs, isLibrary pkg, isHsPackage pkg
+                                             , pkgName pkg /= "Win32" ]
 
--- # Make the haddocking depend on the library .a file, to ensure
--- # that we wait until the library is fully built before we haddock it
--- $$($$($1_PACKAGE)-$$($1_$2_VERSION)_HADDOCK_FILE) : $$($1_$2_$$(HADDOCK_WAY)_LIB)
--- endif
+----------------------------------------------------------------------
+-- PDF
+
+-- | Build all PDF documentation
+buildPdfDocumentation :: Rules ()
+buildPdfDocumentation = mapM_ buildSphinxPdf docPaths
+
+-- | Compile a Sphinx ReStructured Text package to LaTeX
+buildSphinxPdf :: FilePath -> Rules ()
+buildSphinxPdf path = do
+    "//" ++ path <.> "pdf" %> \file -> do
+        let context = vanillaContext Stage0 docPackage
+        withTempDir $ \dir -> do
+            -- TODO: Figure out a crutch
+            build $ target context (Sphinx Latex) [pathPath path] [dir]
+            --runBuilderWithCmdOptions [Cwd dir] Xelatex ["-halt-on-error"
+            --                                           , name <.> "tex" ] [] []
+            unit $ cmd Shell [Cwd dir] ["xelatex", "-halt-on-error"
+                                                 , path <.> "tex" ]
+            unit $ cmd Shell [Cwd dir] ["xelatex", "-halt-on-error"
+                                                 , path <.> "tex" ]
+            unit $ cmd Shell [Cwd dir] ["xelatex", "-halt-on-error"
+                                                 , path <.> "tex" ]
+            unit $ cmd Shell [Cwd dir] ["makeindex", path <.> "idx"]
+            unit $ cmd Shell [Cwd dir] ["xelatex", "-halt-on-error"
+                                                 , path <.> "tex" ]
+            unit $ cmd Shell [Cwd dir] ["xelatex", "-halt-on-error"
+                                                 , path <.> "tex" ]
+            copyFileUntracked (dir -/- path <.> "pdf") file
+
+----------------------------------------------------------------------
+-- Archive
+
+-- | Build archives of documentation
+buildDocumentationArchives :: Rules ()
+buildDocumentationArchives = mapM_ buildArchive docPaths
+
+buildArchive :: FilePath -> Rules ()
+buildArchive path = do
+    "//" ++ pathArchive path %> \file -> do
+        root <- buildRoot
+        let context = vanillaContext Stage0 docPackage
+            src = root -/- pathIndex path
+        need [src]
+        build $ target context (Tar Create) [takeDirectory src] [file]

--- a/src/Rules/Gmp.hs
+++ b/src/Rules/Gmp.hs
@@ -104,7 +104,7 @@ gmpRules = do
         withTempDir $ \dir -> do
             let tmp = unifyPath dir
             need [tarball]
-            build $ target gmpContext Tar [tarball] [tmp]
+            build $ target gmpContext (Tar Extract) [tarball] [tmp]
 
             let patch     = gmpBase -/- "gmpsrc.patch"
                 patchName = takeFileName patch

--- a/src/Rules/Install.hs
+++ b/src/Rules/Install.hs
@@ -210,9 +210,6 @@ installPackages = do
                 quietly $ copyDirectoryContentsUntracked (Not excluded)
                     installDistDir (installDistDir -/- "build")
 
-                whenM (isSpecified HsColour) $
-                    build $ target context GhcCabalHsColour [cabalFile] []
-
                 pref <- setting InstallPrefix
                 unit $ cmd ghcCabalInplace [ "copy"
                                            , pkgPath pkg

--- a/src/Rules/Libffi.hs
+++ b/src/Rules/Libffi.hs
@@ -88,7 +88,7 @@ libffiRules = do
         removeDirectory (root -/- libname)
         -- TODO: Simplify.
         actionFinally (do
-            build $ target libffiContext Tar [tarball] [root]
+            build $ target libffiContext (Tar Extract) [tarball] [root]
             moveDirectory (root -/- libname) libffiPath) $
                 removeFiles root [libname <//> "*"]
 

--- a/src/Rules/SourceDist.hs
+++ b/src/Rules/SourceDist.hs
@@ -19,7 +19,7 @@ sourceDistRules = do
             dropTarXz = dropExtension . dropExtension
             treePath  = "sdistprep/ghc" -/- dropTarXz tarName
         prepareTree treePath
-        runBuilderWithCmdOptions [Cwd "sdistprep/ghc"] Tar
+        runBuilderWithCmdOptions [Cwd "sdistprep/ghc"] (Tar Create)
             ["cJf", ".." -/- tarName,  dropTarXz tarName]
             ["cJf", ".." -/- tarName] [dropTarXz tarName]
     "GIT_COMMIT_ID" %> \fname ->

--- a/src/Rules/Test.hs
+++ b/src/Rules/Test.hs
@@ -31,7 +31,7 @@ testRules = do
         top      <- topDirectory
         compiler <- builderPath $ Ghc CompileHs Stage2
         ghcPkg   <- builderPath $ GhcPkg Update Stage1
-        haddock  <- builderPath Haddock
+        haddock  <- builderPath (Haddock BuildPackage)
         threads  <- shakeThreads <$> getShakeOptions
         debugged <- ghcDebugged <$> flavour
         ghcWithNativeCodeGenInt <- fromEnum <$> ghcWithNativeCodeGen

--- a/src/Settings/Builders/GhcCabal.hs
+++ b/src/Settings/Builders/GhcCabal.hs
@@ -1,5 +1,5 @@
 module Settings.Builders.GhcCabal (
-    ghcCabalBuilderArgs, ghcCabalHsColourBuilderArgs
+    ghcCabalBuilderArgs
     ) where
 
 import Hadrian.Haskell.Cabal
@@ -21,7 +21,6 @@ ghcCabalBuilderArgs = builder GhcCabal ? do
             , withStaged (GhcPkg Update)
             , bootPackageDatabaseArgs
             , libraryArgs
-            , with HsColour
             , configureArgs
             , bootPackageConstraints
             , withStaged $ Cc CompileC
@@ -31,13 +30,6 @@ ghcCabalBuilderArgs = builder GhcCabal ? do
             , with Happy
             , verbosity < Chatty ? pure [ "-v0", "--configure-option=--quiet"
                 , "--configure-option=--disable-option-checking"  ] ]
-
-ghcCabalHsColourBuilderArgs :: Args
-ghcCabalHsColourBuilderArgs = builder GhcCabalHsColour ? do
-    srcPath <- pkgPath <$> getPackage
-    top     <- expr topDirectory
-    path    <- getBuildPath
-    pure [ "hscolour", srcPath, top -/- path ]
 
 -- TODO: Isn't vanilla always built? If yes, some conditions are redundant.
 -- TODO: Need compiler_stage1_CONFIGURE_OPTS += --disable-library-for-ghci?
@@ -110,7 +102,6 @@ withBuilderKey b = case b of
     Alex       -> "--with-alex="
     Happy      -> "--with-happy="
     GhcPkg _ _ -> "--with-ghc-pkg="
-    HsColour   -> "--with-hscolour="
     _          -> error $ "withBuilderKey: not supported builder " ++ show b
 
 -- Expression 'with Alex' appends "--with-alex=/path/to/alex" and needs Alex.

--- a/src/Settings/Builders/Haddock.hs
+++ b/src/Settings/Builders/Haddock.hs
@@ -14,34 +14,50 @@ versionToInt s = case map read . words $ replaceEq '.' ' ' s of
     _                     -> error "versionToInt: cannot parse version."
 
 haddockBuilderArgs :: Args
-haddockBuilderArgs = withHsPackage $ \cabalFile -> builder Haddock ? do
-    output   <- getOutput
-    pkg      <- getPackage
-    path     <- getBuildPath
-    version  <- expr $ pkgVersion  cabalFile
-    synopsis <- expr $ pkgSynopsis cabalFile
-    deps     <- getPkgDataList DepNames
-    haddocks <- expr . haddockDependencies =<< getContext
-    hVersion <- expr $ pkgVersion (unsafePkgCabalFile haddock) -- TODO: improve
-    ghcOpts  <- haddockGhcArgs
-    mconcat
-        [ arg $ "--odir=" ++ takeDirectory output
-        , arg "--verbosity=0"
-        , arg "--no-tmp-comp-dir"
-        , arg $ "--dump-interface=" ++ output
-        , arg "--html"
-        , arg "--hyperlinked-source"
-        , arg "--hoogle"
-        , arg $ "--title=" ++ pkgName pkg ++ "-" ++ version ++ ": " ++ synopsis
-        , arg $ "--prologue=" ++ path -/- "haddock-prologue.txt"
-        , arg $ "--optghc=-D__HADDOCK_VERSION__=" ++ show (versionToInt hVersion)
-        , map ("--hide=" ++) <$> getPkgDataList HiddenModules
-        , pure [ "--read-interface=../" ++ dep
-                 ++ ",../" ++ dep ++ "/src/%{MODULE}.html#%{NAME},"
-                 ++ haddock | (dep, haddock) <- zip deps haddocks ]
-        , pure [ "--optghc=" ++ opt | opt <- ghcOpts ]
-        , getInputs
-        , arg "+RTS"
-        , arg $ "-t" ++ path -/- "haddock.t"
-        , arg "--machine-readable"
-        , arg "-RTS" ]
+haddockBuilderArgs = withHsPackage $ \cabalFile -> mconcat
+    [ builder (Haddock BuildIndex) ? do
+        output <- getOutput
+        inputs <- getInputs
+        mconcat
+            [ arg "--gen-index"
+            , arg "--gen-contents"
+            , arg "-o", arg $ takeDirectory output
+            , arg "-t", arg "Haskell Hierarchical Libraries"
+            , arg "-p", arg "libraries/prologue.txt"
+            , pure [ "--read-interface="
+                     ++ (takeFileName . takeDirectory) haddock
+                     ++ "," ++ haddock | haddock <- inputs ] ]
+
+    , builder (Haddock BuildPackage) ? do
+        output   <- getOutput
+        pkg      <- getPackage
+        path     <- getBuildPath
+        version  <- expr $ pkgVersion  cabalFile
+        synopsis <- expr $ pkgSynopsis cabalFile
+        deps     <- getPkgDataList DepNames
+        haddocks <- expr . haddockDependencies =<< getContext
+        hVersion <- expr $ pkgVersion (unsafePkgCabalFile haddock) -- TODO: improve
+        ghcOpts  <- haddockGhcArgs
+        mconcat
+            [ arg $ "--odir=" ++ takeDirectory output
+            , arg "--verbosity=0"
+            , arg "--no-tmp-comp-dir"
+            , arg $ "--dump-interface=" ++ output
+            , arg "--html"
+            , arg "--hyperlinked-source"
+            , arg "--hoogle"
+            , arg $ "--title=" ++ pkgName pkg ++ "-" ++ version
+                    ++ ": " ++ synopsis
+            , arg $ "--prologue=" ++ path -/- "haddock-prologue.txt"
+            , arg $ "--optghc=-D__HADDOCK_VERSION__="
+                    ++ show (versionToInt hVersion)
+            , map ("--hide=" ++) <$> getPkgDataList HiddenModules
+            , pure [ "--read-interface=../" ++ dep
+                     ++ ",../" ++ dep ++ "/src/%{MODULE}.html#%{NAME},"
+                     ++ haddock | (dep, haddock) <- zip deps haddocks ]
+            , pure [ "--optghc=" ++ opt | opt <- ghcOpts ]
+            , getInputs
+            , arg "+RTS"
+            , arg $ "-t" ++ path -/- "haddock.t"
+            , arg "--machine-readable"
+            , arg "-RTS" ] ]

--- a/src/Settings/Builders/Sphinx.hs
+++ b/src/Settings/Builders/Sphinx.hs
@@ -1,0 +1,22 @@
+module Settings.Builders.Sphinx (sphinxBuilderArgs) where
+
+import Settings.Builders.Common
+
+sphinxBuilderArgs :: Args
+sphinxBuilderArgs = do
+    outPath <- getOutput
+    mconcat [ builder (Sphinx Html) ? mconcat
+                [ arg "-b", arg "html"
+                , arg "-d", arg $ outPath -/- ".doctrees-html"
+                , arg =<< getInput
+                , arg outPath ]
+            , builder (Sphinx Latex) ? mconcat
+                [ arg "-b", arg "latex"
+                , arg "-d", arg $ outPath -/- ".doctrees-latex"
+                , arg =<< getInput
+                , arg outPath ]
+            , builder (Sphinx Man) ? mconcat
+                [ arg "-b", arg "latex"
+                , arg "-d", arg $ outPath -/- ".doctrees-man"
+                , arg =<< getInput
+                , arg outPath ] ]

--- a/src/Settings/Builders/Tar.hs
+++ b/src/Settings/Builders/Tar.hs
@@ -3,8 +3,18 @@ module Settings.Builders.Tar (tarBuilderArgs) where
 import Settings.Builders.Common
 
 tarBuilderArgs :: Args
-tarBuilderArgs = builder Tar ? mconcat [ arg "-xf"
-                                       , input "*.gz"  ? arg "--gzip"
-                                       , input "*.bz2" ? arg "--bzip2"
-                                       , arg =<< getInput
-                                       , arg "-C", arg =<< getOutput ]
+tarBuilderArgs = do
+    mconcat [ builder (Tar Create) ? mconcat
+                [ arg "-c"
+                , output "//*.gz" ? arg "--gzip"
+                , output "//*.bz2" ? arg "--bzip2"
+                , output "//*.xz" ? arg "--xz"
+                , arg "-f", arg =<< getOutput
+                , getInputs ]
+            , builder (Tar Extract) ? mconcat
+                [ arg "-x"
+                , input "*.gz"  ? arg "--gzip"
+                , input "*.bz2" ? arg "--bzip2"
+                , input "*.xz" ? arg "--xz"
+                , arg "-f", arg =<< getInput
+                , arg "-C", arg =<< getOutput ] ]

--- a/src/Settings/Builders/Xelatex.hs
+++ b/src/Settings/Builders/Xelatex.hs
@@ -1,0 +1,7 @@
+module Settings.Builders.Xelatex (xelatexBuilderArgs) where
+
+import Settings.Builders.Common
+
+xelatexBuilderArgs :: Args
+xelatexBuilderArgs = builder Xelatex ? mconcat [ arg "-halt-on-error"
+                                               , arg =<< getInput ]

--- a/src/Settings/Default.hs
+++ b/src/Settings/Default.hs
@@ -27,7 +27,9 @@ import Settings.Builders.Hsc2Hs
 import Settings.Builders.HsCpp
 import Settings.Builders.Ld
 import Settings.Builders.Make
+import Settings.Builders.Sphinx
 import Settings.Builders.Tar
+import Settings.Builders.Xelatex
 import Settings.Packages.Base
 import Settings.Packages.Cabal
 import Settings.Packages.Compiler
@@ -148,7 +150,6 @@ defaultBuilderArgs = mconcat
     , ghcBuilderArgs
     , ghcCbuilderArgs
     , ghcCabalBuilderArgs
-    , ghcCabalHsColourBuilderArgs
     , ghcMBuilderArgs
     , ghcPkgBuilderArgs
     , haddockBuilderArgs
@@ -157,7 +158,9 @@ defaultBuilderArgs = mconcat
     , hsCppBuilderArgs
     , ldBuilderArgs
     , makeBuilderArgs
-    , tarBuilderArgs ]
+    , sphinxBuilderArgs
+    , tarBuilderArgs
+    , xelatexBuilderArgs ]
 
 -- TODO: Disable warnings for Windows specifics.
 -- TODO: Move this elsewhere?

--- a/src/Settings/Packages/Compiler.hs
+++ b/src/Settings/Packages/Compiler.hs
@@ -43,4 +43,4 @@ compilerPackageArgs = package compiler ? do
               , ghcProfiled <$> flavour ?
                 notStage0 ? arg "--ghc-pkg-option=--force" ]
 
-            , builder Haddock ? arg ("--optghc=-I" ++ path) ]
+            , builder (Haddock BuildPackage) ? arg ("--optghc=-I" ++ path) ]


### PR DESCRIPTION
Hello,

I am working on [Trac 14144](https://ghc.haskell.org/trac/ghc/ticket/14144). I thought it reasonable to revamp the doc building here rather than in the Make-based system. In short, this patch lets you run:

`$ ./build.cabal.sh --haddock docs`

Which will generate:

```
$ tree -L 2 _build/docs
_build/docs/
├── archives
│   ├── Haddock.html.tar.xz
│   ├── libraries.html.tar.xz
│   └── users_guide.html.tar.xz
├── html
│   ├── Haddock
│   ├── libraries
│   └── users_guide
└── pdfs
    ├── Haddock.pdf
    └── users_guide.pdf
```

Where the `libraries` folder holds haddocks and colored sources.

This is not ready quite yet, as there are a couple sticking points that I could use advice on:

1.) I would like to run the Sphinx or Xelatex builders on documentation "packages", like the users' guide at `ghc/docs/users_guide` or the Haddock guide at `ghc/utils/haddock/doc`. However, there is currently no way to represent these as `Package`'s. I tried adding some infrastructure for them into Hadrian, but it felt a little hack-y, in part because there are only two at the moment (ignoring Cabal which has some other issues). However, running the builders directly like I did with Xelatex also doesn't feel like the right way to do it. 

The current version just makes a bogus context for callling the Sphinx builder and manually calls the Xelatex builder, so you can see the difference.

2.) Being forced to use the `--haddock` flag as well as the target `docs` feels wrong to me. I looked, but couldn't tell if it was possible to imply a flag based on a target. Alternatively, I could build in the necessary rules, but then I don't know what would happen if someone did specify `--haddock docs` at the command line.

On a brighter note, some wins of this implementation:

- Haddock's `--hyperlinked-source` completely eliminates the need for HsColour and ghc-cabal's coloring. It also has nicer features.
- The `--read-interface` flag generation is more consistent, and so cross module links in the haddocks are working.
- This eliminates the need for the `libraries/gen_contents_index` script.
- This creates a centralized documentation directory, so distribution and installation will be very easy.
- The dependency on Cabal/ghc-cabal has been greatly reduced, so it should be easier to support building all documentation on any platform. (I also just realized `docs` might not build on Windows because I didn't filter `unix` from the haddocks. We need `package-data.mk` to run the haddocks, but Win32 can't be configured on Unix, and possible vice-versa. I'm going to look into this.)

Hopefully this helps!
