### PR TITLE
Fix usage of -with-rtsopts

### DIFF
--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -133,10 +133,9 @@ executable hadrian
                        -Wredundant-constraints
                        -fno-warn-name-shadowing
                        -rtsopts
-                       -- Disable idle GC to avoid redundant GCs while waiting
-                       -- for external processes
-                       -with-rtsopts=-I0
-                       -- Don't use parallel GC as the synchronization time tends to eat any
-                       -- benefit.
-                       -with-rtsopts=-qg0
+                       -- * -I0: Disable idle GC to avoid redundant GCs while
+                       --        waiting for external processes
+                       -- * -qg: Don't use parallel GC as the synchronization
+                       --        time tends to eat any benefit.
+                       "-with-rtsopts=-I0 -qg"
                        -threaded


### PR DESCRIPTION
When I added `-qg` to the default RTS options in
57cfa03c23047bb0c731428e97ca716d9a1cf312 (#385) I neglected to consider that it
the -with-rtsopts flag would override the previous flag setting `-I0`. This
had the effect of reenabling idle GC, causing GC time to regress terribly. I
likely didn't notice this since I had passed the flags directly to the `hadrian`
executable with `+RTS` while testing.

Moreover, I mistakenly wrote `-qg0`, which (somewhat confusingly)
actually *enables* parallel GC. Instead I wanted to write `-qg`.