### PR TITLE
Build with CABAL_PARSEC flag

### DIFF
--- a/src/Settings/Packages/GhcCabal.hs
+++ b/src/Settings/Packages/GhcCabal.hs
@@ -15,6 +15,7 @@ ghcCabalPackageArgs = stage0 ? package ghcCabal ? builder Ghc ? do
         , arg "--make"
         , arg "-j"
         , arg ("-DCABAL_VERSION=" ++ replace "." "," cabalVersion)
+        , arg "-DCABAL_PARSEC"
         , arg "-DBOOTSTRAPPING"
         , arg "-DMIN_VERSION_binary_0_8_0"
         , arg "-ilibraries/Cabal/Cabal"


### PR DESCRIPTION
This was incorporated into the make-based build system in
36fe21aa3fe5abe1cef0104b20c296ac9385658d.