### PR TITLE
Fix AppVeyor cache failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,8 @@ install:
     - git clone --recursive git://git.haskell.org/ghc.git
     # GHC comes with an older version of Hadrian, so we delete it
     - rm -rf ghc\hadrian
-    # Move new Hadrian into ./ghc/hadrian
-    - mv new-hadrian ghc\hadrian
+    # Copy new Hadrian into ./ghc/hadrian
+    - cp -r new-hadrian ghc\hadrian
 
     # Install Alex and Happy
     - set PATH=C:\Users\appveyor\AppData\Roaming\local\bin;%PATH%


### PR DESCRIPTION
See the end of this log: https://ci.appveyor.com/project/snowleopard/hadrian/build/1.0.788
```
Updating build cache...
Cache 'c:\sr' - Calculating dependencies checksum...Error calculating dependencies CRC for c:\sr: Error calculating CRC32 for c:\new-hadrian\appveyor.yml: The system cannot find the path specified
Build success
```