### PR TITLE
Unbreak `cabal new-build`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,5 @@
 packages: ./
           ../libraries/Cabal/Cabal/
-          ../libraries/filepath/
           ../libraries/text/
           ../libraries/hpc/
           ../libraries/parsec/


### PR DESCRIPTION
Using a local `filepath` forces `new-build` to build the
non-local build-tool `alex` as in-place which however isn't supported properly
by `cabal new-build` yet (this will be fixed at the earliest in cabal 2.2) and thus
breaks `hadrian/build.sh` for me.