### PR TITLE
Add ways to build hadrian using nix

### DIFF
--- a/build-nix
+++ b/build-nix
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash shell.nix
+
+function rl {
+    TARGET_FILE="$1"
+
+    cd "$(dirname "$TARGET_FILE")"
+    TARGET_FILE="$(basename "$TARGET_FILE")"
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+        TARGET_FILE="$(readlink "$TARGET_FILE")"
+        cd "$(dirname "$TARGET_FILE")"
+        TARGET_FILE="$(basename "$TARGET_FILE")"
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    PHYS_DIR="$(pwd -P)"
+    RESULT="$PHYS_DIR/$TARGET_FILE"
+    echo "$RESULT"
+}
+
+absoluteRoot="$(dirname "$(rl "$0")")"
+echo $absoluteRoot
+cd "$absoluteRoot"
+
+hadrian         \
+  --lint                         \
+  --directory="$absoluteRoot/.." \
+  "$@"

--- a/build.nix.sh
+++ b/build.nix.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i bash shell.nix
 
+# This script sets up the build environment by invoking nix-shell shell.nix
+# and then runs the hadrian executable.
+
 function rl {
     TARGET_FILE="$1"
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,57 @@
+{ nixpkgs ? import <nixpkgs> {} }:
+
+let
+  haskellPackages = nixpkgs.haskell.packages.ghc821;
+
+  removeBuild = path: type:
+    let baseName = baseNameOf (toString path);
+    in
+        ! (baseName == "_build"
+           || baseName == "dist"
+           || baseName == "dist-newstyle"
+           || baseName == ".stack-work"
+           || baseName == "config.log"
+           || baseName == "config.status"
+           || nixpkgs.lib.hasSuffix ".sh" baseName
+           || !(nixpkgs.lib.cleanSourceFilter path type)) ;
+
+  filterSrc = path: builtins.filterSource removeBuild path;
+
+
+  hadrianPackages = nixpkgs.haskell.packages.ghc821.override {
+    overrides = self: super: let
+        localPackage = name: path: self.callCabal2nix name (filterSrc path) {};
+      in {
+        hadrian = localPackage "hadrian" ./. ;
+        shake = self.callHackage "shake" "0.16" {};
+        Cabal = localPackage "Cabal" ./../libraries/Cabal/Cabal ;
+        filepath = localPackage "filepath" ./../libraries/filepath ;
+        text = localPackage "text" ./../libraries/text  ;
+        hpc = localPackage"hpc" ./../libraries/hpc ;
+        parsec = localPackage "parsec" ./../libraries/parsec ;
+        HUnit = nixpkgs.haskell.lib.dontCheck (self.callHackage "HUnit" "1.3.1.2" {});
+        process = localPackage "process" ./../libraries/process ;
+        directory = localPackage "directory" ./../libraries/directory ;
+      }; };
+
+in
+
+  nixpkgs.stdenv.mkDerivation {
+    name = "ghc-dev";
+    buildInputs = [
+                    hadrianPackages.hadrian
+                    nixpkgs.haskell.compiler.ghc821
+                    haskellPackages.alex
+                    haskellPackages.happy
+                    nixpkgs.python3
+                    nixpkgs.git
+                    nixpkgs.autoconf
+                    nixpkgs.automake
+                    nixpkgs.perl
+                    nixpkgs.gcc
+                    nixpkgs.python3Packages.sphinx
+                    nixpkgs.ncurses
+                    nixpkgs.m4
+                    nixpkgs.gmp
+                    nixpkgs.file ];
+  }

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,7 @@
+# Invoking nix-shell sets up an environment where we can build ghc
+# by only invoking hadrian.
+
+
 { nixpkgs ? import <nixpkgs> {} }:
 
 let


### PR DESCRIPTION
This adds two new files to the hadrian directory

    shell.nix sets up the build envrionment you need to build ghc
    build-nix is a simple wrapper which invokes hadrian in the correct environment

Note: this patch was authored by @mpickering, however it ended up on phabricator due to the subtree as https://phabricator.haskell.org/D4207.