### PR TITLE
Do not depend on the in-tree filepath library

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,6 @@ resolver: lts-9.0
 packages:
 - '.'
 - '../libraries/Cabal/Cabal'
-- '../libraries/filepath'
 - '../libraries/hpc'
 - '../libraries/parsec'
 - '../libraries/text'


### PR DESCRIPTION
See #465, #466