### PR TITLE
Fix broken colours with `-j`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ on Cabal sandboxes (`build.cabal.*`), Stack (`build.stack.*`) or the global pack
 (`build.global-db.*`). Also see [instructions for building GHC on Windows using Stack][windows-build].
 
 * Hadrian is written in Haskell and depends on `shake` (plus a few packages that `shake` depends on),
-`ansi-terminal`, `mtl`, `quickcheck`, and GHC core libraries.
+`mtl`, `quickcheck`, and GHC core libraries.
 
 * If you have never built GHC before, start with the [preparation guide][ghc-preparation].
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
     - brew update
     - brew install ghc cabal-install python3
     - cabal update
-    - cabal install alex happy ansi-terminal mtl shake quickcheck
+    - cabal install alex happy mtl shake quickcheck
   cache_directories:
     - $HOME/.cabal
     - $HOME/.ghc

--- a/doc/user-settings.md
+++ b/doc/user-settings.md
@@ -204,9 +204,20 @@ used by default by overriding `buildProgressColour` and `successColour`:
 ```haskell
 -- | Set colour for build progress messages (e.g. executing a build command).
 buildProgressColour :: BuildProgressColour
-buildProgressColour = BuildProgressColour (Dull, Magenta)
+buildProgressColour = BuildProgressColour (Dull Magenta)
 
 -- | Set colour for success messages (e.g. a package is built successfully).
 successColour :: SuccessColour
-successColour = SuccessColour (Dull, Green)
+successColour = SuccessColour (Dull Green)
+```
+
+Your options are `Dull Colour`, `Vivid Colour`, or `Extended Code`. `Dull`
+colours are the ANSI 8-bit colours, `Vivid` correspond to the 16-bit codes that
+end with ";1", and `Extended` let's you enter a manual code for the 256 colour
+set. E.g.
+
+```
+Dull Blue
+Vivid Cyan
+Extended "203"
 ```

--- a/doc/user-settings.md
+++ b/doc/user-settings.md
@@ -204,11 +204,11 @@ used by default by overriding `buildProgressColour` and `successColour`:
 ```haskell
 -- | Set colour for build progress messages (e.g. executing a build command).
 buildProgressColour :: BuildProgressColour
-buildProgressColour = BuildProgressColour (Dull Magenta)
+buildProgressColour = mkBuildProgressColour (Dull Magenta)
 
 -- | Set colour for success messages (e.g. a package is built successfully).
 successColour :: SuccessColour
-successColour = SuccessColour (Dull Green)
+successColour = mkSuccessColour (Dull Green)
 ```
 
 Your options are `Dull Colour`, `Vivid Colour`, or `Extended Code`. `Dull`

--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -117,7 +117,6 @@ executable hadrian
     other-extensions:    MultiParamTypeClasses
                        , TypeFamilies
     build-depends:       base                 >= 4.8     && < 5
-                       , ansi-terminal        == 0.6.*
                        , Cabal                >= 2.0.0.2 && < 2.2
                        , containers           == 0.5.*
                        , directory            >= 1.2     && < 1.4

--- a/src/UserSettings.hs
+++ b/src/UserSettings.hs
@@ -8,7 +8,6 @@ module UserSettings (
     ) where
 
 import Hadrian.Utilities
-import System.Console.ANSI
 
 import Flavour
 import Expression
@@ -46,11 +45,11 @@ verboseCommand = do
 
 -- | Set colour for build progress messages (e.g. executing a build command).
 buildProgressColour :: BuildProgressColour
-buildProgressColour = BuildProgressColour (Dull, Magenta)
+buildProgressColour = mkBuildProgressColour Dull Magenta
 
 -- | Set colour for success messages (e.g. a package is built successfully).
 successColour :: SuccessColour
-successColour = SuccessColour (Dull, Green)
+successColour = mkSuccessColour Dull Green
 
 -- TODO: Set this flag from the command line.
 -- | Set this flag to 'True' to disable building Stage2 GHC (i.e. the @ghc-stage2@

--- a/src/UserSettings.hs
+++ b/src/UserSettings.hs
@@ -45,11 +45,11 @@ verboseCommand = do
 
 -- | Set colour for build progress messages (e.g. executing a build command).
 buildProgressColour :: BuildProgressColour
-buildProgressColour = mkBuildProgressColour Dull Magenta
+buildProgressColour = mkBuildProgressColour (Dull Magenta)
 
 -- | Set colour for success messages (e.g. a package is built successfully).
 successColour :: SuccessColour
-successColour = mkSuccessColour Dull Green
+successColour = mkSuccessColour (Dull Green)
 
 -- TODO: Set this flag from the command line.
 -- | Set this flag to 'True' to disable building Stage2 GHC (i.e. the @ghc-stage2@


### PR DESCRIPTION
Doing the high-impact work, I have fixed the colored output when running with
`-j` :P This patch also removes `ansi-terminal` as a dependency, which will be
easier to explain in a second.

The root of the issue is that hadrian currently outputs:

```
\ESC[34m<SOME OUTPUT>\n
\ESC[0m
```

with newline character added for emphasis. My brief research suggests `stdout`
is typically line buffered, so the final reset code can break other lines.

If you chase Shake's definition of `putNormal` all the way to
https://github.com/ndmitchell/shake/blob/c9c4246ec6e9d3ca80eabea10d64e01b6c70d094/src/Development/Shake/Internal/Core/Run.hs#L75,
you can see that it uses locks. So if we can combine the color and message
output into a single `putNormal` call, we can drop a fair bit of the logic.

This means we have to manually construct the color codes, but that is fairly
easy. The `setSGR` code that was being used boils down to: `hPutStr
"\ESC[<color>m"`. It only takes two small data types and some helper functions
to do that in this code. We also get access to the extended 256 color set with
~2 lines of extra code, for output color connoisseurs.

Shake actually uses a simplified version of this internally here,
https://github.com/ndmitchell/shake/blob/be4333474930ff30c7232894be66bdbb93f01702/src/Development/Shake/Internal/Args.hs#L244.

After taking that functionality from `ansi-terminal`, the only use left was
`hSupportsANSI`. That code is a two-liner borrowed from HSpec,
https://github.com/hspec/hspec/commit/d932f03317e0e2bd08c85b23903fb8616ae642bd.
Recreating that in this code is also fairly easy.

I get that removing a dependency is a little aggressive, so if you want me to
tone is down I can.

As for testing, I ran a full build on Debian and Mac with no errors. I am not
brave enough to do anything on Windows. It is also a little hard to test these
kinds of bugs; but almost all of the responsibility is on Shake now, so it
makes our lives easier.
