### PR TITLE
Drop redundant dependencies on in-tree packages

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,2 @@
 packages: ./
           ../libraries/Cabal/Cabal/
-          ../libraries/hpc/
-          ../libraries/parsec/
-          ../libraries/text/

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,9 +7,6 @@ resolver: lts-9.0
 packages:
 - '.'
 - '../libraries/Cabal/Cabal'
-- '../libraries/hpc'
-- '../libraries/parsec'
-- '../libraries/text'
 
 extra-deps:
 - shake-0.16


### PR DESCRIPTION
See #481 

Note that we might need to reverse this when we merge `ghc-cabal` into Hadrian (see #445).