### PR TITLE
Build timeout program with `buildProgram` rules on windows.

### DIFF
--- a/src/GHC.hs
+++ b/src/GHC.hs
@@ -109,7 +109,8 @@ testsuitePackages = return [ checkApiAnnotations
                            , checkPpr
                            , ghcPkg
                            , parallel
-                           , hp2ps              ]
+                           , hp2ps
+                           , timeout         ]
 
 -- | Given a 'Context', compute the name of the program that is built in it
 -- assuming that the corresponding package's type is 'Program'. For example, GHC

--- a/src/GHC/Packages.hs
+++ b/src/GHC/Packages.hs
@@ -17,7 +17,8 @@ ghcPackages =
     , ghcHeap, ghci, ghcPkg, ghcPrim, ghcTags, haddock, haskeline, hsc2hs, hp2ps
     , hpc, hpcBin, integerGmp, integerSimple, iserv, libffi, libiserv, mtl
     , parsec, parallel, pretty, process, rts, runGhc, stm, templateHaskell
-    , terminfo, text, time, touchy, transformers, unlit, unix, win32, xhtml ]
+    , terminfo, text, time, touchy, transformers, unlit, unix, win32, xhtml
+    , timeout ]
 
 -- TODO: Optimise by switching to sets of packages.
 isGhcPackage :: Package -> Bool
@@ -81,6 +82,7 @@ unlit               = hsUtil "unlit"
 unix                = hsLib  "unix"
 win32               = hsLib  "Win32"
 xhtml               = hsLib  "xhtml"
+timeout             = hsUtil "timeout"         `setPath` "testsuite/timeout"
 
 -- | Construct a Haskell library package, e.g. @array@.
 hsLib :: PackageName -> Package


### PR DESCRIPTION
Hi, @snowleopard, I'm working on the timeout program in testsuite on windows. I'm trying to build the `testsuite/timeout` using the `buildProgram` rules, just like other utils programs.

I have added the program definition in `GHC.hs`:

~~~haskell
timeout             = hsPrg  "timeout"         `setPath` "testsuite/timeout"
~~~

However I'm lost in the following error message when execute `./hadrian-ghc.sh inplace/bin/timeout.exe`:

~~~
Error when running Shake build system:
* inplace/bin/timeout.exe
* _build/stage0/testsuite/timeout/WinCBindings.o
* _build/stage0/testsuite/timeout/WinCBindings.o _build/stage0/testsuite/timeout/WinCBindings.hi
* OracleQ (KeyValues ("_build/stage0/testsuite/timeout/.dependencies","_build/stage0/testsuite/timeout/WinCBindings.o"))
* _build/stage0/testsuite/timeout/.dependencies
* _build/stage0/testsuite/timeout/Main.hs
No generator for _build/stage0/testsuite/timeout/Main.hs.
CallStack (from HasCallStack):
  error, called at src\Rules\Generate.hs:108:38 in main:Rules.Generate
~~~

Could you provide me some hints about this problem ?