### PR TITLE
Relax Cabal constraint

### DIFF
--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -118,7 +118,7 @@ executable hadrian
     other-extensions:    MultiParamTypeClasses
                        , TypeFamilies
     build-depends:       base                 >= 4.8     && < 5
-                       , Cabal                >= 2.1.0.0 && < 2.2
+                       , Cabal                >= 2.1.0.0 && < 2.3
                        , containers           == 0.5.*
                        , directory            >= 1.2     && < 1.4
                        , extra                >= 1.4.7


### PR DESCRIPTION
As the Cabal 2.2 release branch has been cut, we need to relax the constraint on Cabal in hadrian.