### PR TITLE
ghc-cabal: Parsec modules are now found in libraries/parsec/src

### DIFF
--- a/src/Settings/Packages/GhcCabal.hs
+++ b/src/Settings/Packages/GhcCabal.hs
@@ -28,5 +28,5 @@ ghcCabalPackageArgs = stage0 ? package ghcCabal ? builder Ghc ? do
         , arg "-ilibraries/mtl"
         , arg "-ilibraries/text"
         , arg "-Ilibraries/text/include"
-        , arg "-ilibraries/parsec" ]
+        , arg "-ilibraries/parsec/src" ]
 


### PR DESCRIPTION
This has been the case since https://github.com/haskell/parsec/commit/89d4541f5cf523cf1fb1dffa43179ac0d1b33431.