### PR TITLE
Make shell.nix less broken

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -46,6 +46,7 @@ in
       nativeBuildInputs = drv.nativeBuildInputs ++ 
         [ hadrianPackages.hadrian
           nixpkgs.arcanist
+          nixpkgs.python3Packages.sphinx
         ];
     })
 

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@
 { nixpkgs ? import <nixpkgs> {} }:
 
 let
-  haskellPackages = nixpkgs.haskell.packages.ghc821;
+  haskellPackages = nixpkgs.haskell.packages.ghc822;
 
   removeBuild = path: type:
     let baseName = baseNameOf (toString path);
@@ -23,7 +23,7 @@ let
   filterSrc = path: builtins.filterSource removeBuild path;
 
 
-  hadrianPackages = nixpkgs.haskell.packages.ghc821.override {
+  hadrianPackages = nixpkgs.haskell.packages.ghc822.override {
     overrides = self: super: let
         localPackage = name: path: self.callCabal2nix name (filterSrc path) {};
       in {

--- a/shell.nix
+++ b/shell.nix
@@ -43,9 +43,9 @@ in
   nixpkgs.lib.overrideDerivation nixpkgs.haskell.packages.ghcHEAD.ghc
     (drv: {
       name = "ghc-dev";
-      buildInputs = drv.buildInputs ++ [
-                    hadrianPackages.hadrian
-                    nixpkgs.arcanist
-                    ];
+      nativeBuildInputs = drv.nativeBuildInputs ++ 
+        [ hadrianPackages.hadrian
+          nixpkgs.arcanist
+        ];
     })
 


### PR DESCRIPTION
- The `ghc821` isn't available anymore, using `ghc822` instead
- Dependencies to the `ghcHEAD` package are now specified as `nativeBuildInputs` rather than `buildInputs`
- `./validate` needs sphinx to be installed

I use this setup (minus the `hadrianPackages.hadrian` line) for building GHC. Using hadrian for the build doesn't work, as `nix` fails to install `shake-0.16` which seems to miss [this fix](https://github.com/ndmitchell/shake/commit/31fa7ce765bebb2acceca9a0dd9234320d36655f). I'm not too familiar with nix, but I had to manually update the cabal-hashes tarball which breaks every time I `nix-channel --update`. Last time I tried, it probably broke somewhere else, so I'm just using this file as a base for building GHC HEAD with `make`.