### PR TITLE
Add 'git' to nativeBuildInputs in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -75,6 +75,7 @@ in
       nativeBuildInputs = drv.nativeBuildInputs ++
         [ hadrianPackages.hadrian
           nixpkgs.arcanist
+          nixpkgs.git
           nixpkgs.python3Packages.sphinx
           nixpkgs.texlive.combined.scheme-basic
           (nixpkgs.haskell.packages.ghc822.ghcWithPackages


### PR DESCRIPTION
`configurePhase` in `nix-shell --pure` was failing without it:

```
[nix-shell:~/Projects/ghc]$ configurePhase
Traceback (most recent call last):
  File "./boot", line 193, in <module>
    check_for_url_rewrites()
  File "./boot", line 29, in check_for_url_rewrites
    subprocess.check_output('git config remote.origin.url'.split()).find(b'github.com') != -1 and \
  File "/nix/store/dckjl7420jzqkca22r362sx13klpww76-python3-3.6.3/lib/python3.6/subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "/nix/store/dckjl7420jzqkca22r362sx13klpww76-python3-3.6.3/lib/python3.6/subprocess.py", line 403, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/nix/store/dckjl7420jzqkca22r362sx13klpww76-python3-3.6.3/lib/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/nix/store/dckjl7420jzqkca22r362sx13klpww76-python3-3.6.3/lib/python3.6/subprocess.py", line 1344, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'git': 'git'
configure flags: --prefix=/nix/store/wdcz5yv7q2y0gdb1205js19wv9k5nxl7-ghc-dev --bindir=/nix/store/wdcz5yv7q2y0gdb1205js19wv9k5nxl7-ghc-dev/bin --sbindir=/nix/store/wdcz5yv7q2y0gdb1205js19wv9k5nxl7-ghc-dev/sbin --includedir=/nix/store/wdcz5yv7q2y0gdb1205js19wv9k5nxl7-ghc-dev/include --oldincludedir=/nix/store/wdcz5yv7q2y0gdb1205js19wv9k5nxl7-ghc-dev/include --mandir=/nix/store/wdcz5yv7q2y0gdb1205js19wv9k5nxl7-ghc-dev/share/man --infodir=/nix/store/wdcz5yv7q2y0gdb1205js19wv9k5nxl7-ghc-dev/share/info --docdir=/nix/store/wdqnln712244m6h4v5lp23r8kp9l021p-ghc-dev-doc/share/doc/ghc-dev --libdir=/nix/store/wdcz5yv7q2y0gdb1205js19wv9k5nxl7-ghc-dev/lib --libexecdir=/nix/store/wdcz5yv7q2y0gdb1205js19wv9k5nxl7-ghc-dev/libexec --localedir=/nix/store/wdcz5yv7q2y0gdb1205js19wv9k5nxl7-ghc-dev/share/locale CC=/nix/store/wriy1xis74fybcg3m1jnq5bd5myxvhm6-gcc-wrapper-6.4.0/bin/cc --with-curses-includes=/nix/store/j8igpp362ql5r4bqcjdkllrjcjc28daf-ncurses-6.0-20171125-dev/include --with-curses-libraries=/nix/store/xrgvbjvi6cbksbcy2crgwyyg95zz73af-ncurses-6.0-20171125/lib --datadir=\$doc/share/doc/ghc --with-gmp-includes=/nix/store/604161mmwsjci628xpdjfc5jq9wbaps0-gmp-6.1.2-dev/include --with-gmp-libraries=/nix/store/nbzibhvhmly5yk95d16jli0alabnnj1g-gmp-6.1.2/lib
configure: WARNING: unrecognized options: --with-curses-includes
checking for gfind... no
checking for find... /nix/store/jjzcnj9p38ms9mfaq3w857kpv3s77ygr-findutils-4.6.0/bin/find
checking for sort... /nix/store/240p4s3hkmgcnwg8rlq4vb1wgsjz7lb8-coreutils-8.28/bin/sort
checking for GHC version date... ./configure: line 2920: git: command not found
inferred 8.5.20180319
checking for GHC Git commit id... ./configure: line 2942: git: command not found
configure: error: failed to detect revision: check that git is in your path
```