### PR TITLE
Add clean routines for fs files copied by configure

### DIFF
--- a/src/Rules/Clean.hs
+++ b/src/Rules/Clean.hs
@@ -18,6 +18,19 @@ cleanSourceTree = do
     removeDirectory inplaceBinPath
     removeDirectory inplaceLibPath
     removeDirectory "sdistprep"
+    cleanFsUtils
+
+-- Clean all temporary fs files copied by configure into the source folder
+cleanFsUtils :: Action ()
+cleanFsUtils = do
+    let dirs = [ "utils/lndir/"
+               , "utils/unlit/"
+               , "rts/"
+               , "libraries/base/include/"
+               , "libraries/base/cbits/"
+               ]
+    liftIO $ forM_ dirs (flip removeFiles ["fs.*"])
+
 
 cleanRules :: Rules ()
 cleanRules = "clean" ~> clean


### PR DESCRIPTION
Following https://phabricator.haskell.org/D4416 configure will now be copying or hard-linking certain files to a few packages. the Make based system will remove them on clean.

This patch adds the `Hadrian` part.