### PR TITLE
Move rts I/O Functions in different namespace.

### DIFF
--- a/src/Settings/Packages/Rts.hs
+++ b/src/Settings/Packages/Rts.hs
@@ -112,6 +112,8 @@ rtsPackageArgs = package rts ? do
           , arg $ "-I" ++ path
           , flag UseSystemFfi ? arg ("-I" ++ ffiIncludeDir)
           , arg $ "-DRtsWay=\"rts_" ++ show way ++ "\""
+          -- Set the namespace for the rts fs functions
+          , arg $ "-DFS_NAMESPACE=rts"
           -- RTS *must* be compiled with optimisations. The INLINE_HEADER macro
           -- requires that functions are inlined to work as expected. Inlining
           -- only happens for optimised builds. Otherwise we can assume that
@@ -144,6 +146,14 @@ rtsPackageArgs = package rts ? do
             , "-DTargetVendor="              ++ show targetVendor
             , "-DGhcUnregisterised="         ++ show ghcUnreg
             , "-DGhcEnableTablesNextToCode=" ++ show ghcEnableTNC ]
+
+          -- We're after pur performance here. So make sure fast math and
+          -- vectorization is enabled.
+          , input "//xxhash.c" ? pure
+            [ "-O3"
+            , "-ffast-math"
+            , "-ftree-vectorize"
+            ]
 
             , inputs ["//Evac.c", "//Evac_thr.c"] ? arg "-funroll-loops"
 


### PR DESCRIPTION
Hi,

I'll be landing https://phabricator.haskell.org/D4416 soon but that requires some new build arguments for the `rts` due to Linux. The build will fail without this change.

The flag controls name-mangling of some `I/O` functions. Without it they'll be in the default namespace and the build will fail with an unknown symbol.

Also I noticed `xxhash.c`'s optimization flags were not the same as Make, so I've corrected those.
