### PR TITLE
Preliminary bindist rule

### DIFF
--- a/cfg/system.config.in
+++ b/cfg/system.config.in
@@ -7,6 +7,7 @@
 
 alex           = @AlexCmd@
 ar             = @ArCmd@
+autoreconf     = autoreconf
 cc             = @CC@
 happy          = @HappyCmd@
 hs-cpp         = @HaskellCPPCmd@

--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -51,6 +51,7 @@ executable hadrian
                        , Oracles.Setting
                        , Oracles.ModuleFiles
                        , Rules
+                       , Rules.Bindist
                        , Rules.Clean
                        , Rules.Compile
                        , Rules.Configure

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -88,6 +88,7 @@ instance NFData   HaddockMode
 -- @GhcPkg Stage1@ is the one built in Stage0.
 data Builder = Alex
              | Ar ArMode Stage
+             | Autoreconf FilePath
              | DeriveConstants
              | Cc CcMode Stage
              | Configure FilePath
@@ -173,6 +174,7 @@ instance H.Builder Builder where
 
     runtimeDependencies :: Builder -> Action [FilePath]
     runtimeDependencies = \case
+        Autoreconf dir -> return [dir -/- "configure.ac"]
         Configure dir -> return [dir -/- "configure"]
 
         Ghc _ Stage0 -> return []
@@ -231,6 +233,7 @@ instance H.Builder Builder where
 
                 Ar Unpack _ -> cmd echo [Cwd output] [path] buildArgs
 
+                Autoreconf dir -> cmd echo [Cwd dir] [path] buildArgs
                 Configure dir -> do
                     -- Inject /bin/bash into `libtool`, instead of /bin/sh,
                     -- otherwise Windows breaks. TODO: Figure out why.
@@ -282,6 +285,7 @@ systemBuilderPath builder = case builder of
     Alex            -> fromKey "alex"
     Ar _ Stage0     -> fromKey "system-ar"
     Ar _ _          -> fromKey "ar"
+    Autoreconf _    -> fromKey "autoreconf"
     Cc  _  Stage0   -> fromKey "system-cc"
     Cc  _  _        -> fromKey "cc"
     -- We can't ask configure for the path to configure!

--- a/src/Builder.hs-boot
+++ b/src/Builder.hs-boot
@@ -13,6 +13,7 @@ data HaddockMode = BuildPackage | BuildIndex
 
 data Builder = Alex
              | Ar ArMode Stage
+	     | Autoreconf FilePath
              | DeriveConstants
              | Cc CcMode Stage
              | Configure FilePath

--- a/src/Rules.hs
+++ b/src/Rules.hs
@@ -8,15 +8,16 @@ import qualified Hadrian.Oracles.TextFile
 import Expression
 import GHC
 import qualified Oracles.ModuleFiles
+import qualified Rules.Bindist
 import qualified Rules.Compile
-import qualified Rules.PackageData
+import qualified Rules.Configure
 import qualified Rules.Dependencies
 import qualified Rules.Documentation
 import qualified Rules.Generate
-import qualified Rules.Configure
 import qualified Rules.Gmp
 import qualified Rules.Libffi
 import qualified Rules.Library
+import qualified Rules.PackageData
 import qualified Rules.Program
 import qualified Rules.Register
 import Settings
@@ -122,6 +123,7 @@ packageRules = do
 
 buildRules :: Rules ()
 buildRules = do
+    Rules.Bindist.bindistRules
     Rules.Configure.configureRules
     Rules.Generate.copyRules
     Rules.Generate.generateRules

--- a/src/Rules/Bindist.hs
+++ b/src/Rules/Bindist.hs
@@ -1,0 +1,121 @@
+module Rules.Bindist where
+
+import Expression
+import GHC
+import Oracles.Setting
+import Settings
+import Target
+import Utilities
+
+bindistRules :: Rules ()
+bindistRules = do
+    root <- buildRootRules
+    phony "binary-dist" $ do
+      -- We 'need' all binaries and libraries
+      targets <- mapM pkgTarget =<< stagePackages Stage1
+      need targets
+
+      version <- setting ProjectVersion
+      targetPlatform <- setting TargetPlatformFull
+
+      let ghcBuildDir      = root -/- stageString Stage1
+          bindistFilesDir  = root -/- "bindist" -/- ghcVersionPretty
+          ghcVersionPretty = "ghc-" ++ version ++ "-" ++ targetPlatform
+
+      -- we create the bindist directory at <root>/bindist/ghc-X.Y.Z-platform/
+      -- and populate it with a stage2 build
+      createDirectory bindistFilesDir
+      copyDirectory (ghcBuildDir -/- "bin") bindistFilesDir
+      copyDirectory (ghcBuildDir -/- "lib") bindistFilesDir
+      {- SHOULD WE SHIP DOCS?
+      need ["docs"]
+      copyDirectory (root -/- "docs") bindistFilesDir
+      -}
+
+      -- we then 'need' all the files necessary to configure and install
+      -- (as in, './configure [...] && make install') this build on some
+      -- other machine.
+      need $ map (bindistFilesDir -/-)
+                 (["configure", "Makefile"] ++ bindistInstallFiles)
+
+      -- finally, we create the archive, at
+      -- <root>/bindist/ghc-X.Y.Z-platform.tar.xz
+      command [Cwd $ root -/- "bindist"] "tar"
+        [ "-c", "--xz", "-f"
+        , ghcVersionPretty <.> "tar.xz"
+        , ghcVersionPretty
+        ]
+
+    -- prepare binary distribution configure script
+    -- (generated under <ghc root>/distrib/configure by 'autoreconf')
+    root -/- "bindist" -/- "ghc-*" -/- "configure" %> \configurePath -> do
+      ghcRoot <- topDirectory
+      copyFile (ghcRoot -/- "aclocal.m4") (ghcRoot -/- "distrib" -/- "aclocal.m4")
+      buildWithCmdOptions [] $
+        target (vanillaContext Stage1 ghc) (Autoreconf $ ghcRoot -/- "distrib") [] []
+      -- we clean after ourselves, moving the configure script we generated in
+      -- our bindist dir
+      removeFile (ghcRoot -/- "distrib" -/- "aclocal.m4")
+      moveFile (ghcRoot -/- "distrib" -/- "configure") configurePath
+
+    -- generate the Makefile that enables the "make install" part
+    root -/- "bindist" -/- "ghc-*" -/- "Makefile" %> \makefilePath ->
+      writeFile' makefilePath bindistMakefile
+
+    -- copy over the various configure-related files needed for a working
+    -- './configure [...] && make install' workflow
+    -- (see the list of files needed in the 'binary-dist' rule above, before
+    -- creating the archive).
+    forM_ bindistInstallFiles $ \file ->
+      root -/- "bindist" -/- "ghc-*" -/- file %> \dest -> do
+        ghcRoot <- topDirectory
+        copyFile (ghcRoot -/- fixup file) dest
+
+  where fixup f
+          | f `elem` ["INSTALL", "README"] = "distrib" -/- f
+          | otherwise                      = f
+
+-- | A list of files that allow us to support a simple
+--   @./configure [--prefix=PATH] && make install@ workflow.
+--
+--   NOTE: the list surely is incomplete
+bindistInstallFiles :: [FilePath]
+bindistInstallFiles =
+  [ "config.sub", "config.guess", "install-sh"
+  , "mk" -/- "config.mk.in", "mk" -/- "install.mk.in"
+  , "settings.in", "README", "INSTALL"
+  ]
+
+-- | Auxiliary function that gives us a 'Filepath' we can 'need' for
+--   all libraries and programs that are needed for a complete build.
+--
+--   For libraries, it returns the path to the .conf file in the package db.
+--   For executables, it returns the path to the compiled executable.
+pkgTarget :: Package -> Action FilePath
+pkgTarget pkg
+  | isLibrary pkg = pkgConfFile (Context Stage1 pkg $ read "v")
+  | otherwise     = programPath =<< programContext Stage1 pkg
+
+-- TODO: augment this makefile to match the various parameters that
+-- the current bindist scripts support.
+-- | A trivial makefile that only takes @$prefix@ into account,
+--   and not e.g @$datadir@ (for docs) and other variables, yet.
+bindistMakefile :: String
+bindistMakefile = unlines
+  [ "MAKEFLAGS += --no-builtin-rules"
+  , ".SUFFIXES:"
+  , ""
+  , "include mk/install.mk"
+  , ""
+  , ".PHONY: default"
+  , "default:"
+  , "\t@echo 'Run \"make install\" to install'"
+  , "\t@false"
+  , ""
+  , ".PHONY: install"
+  , "install:"
+  , "\tmkdir -p $(prefix)"
+  , "\tcp settings lib/settings"
+  , "\tcp -R bin $(prefix)/"
+  , "\tcp -R lib $(prefix)/"
+  ]


### PR DESCRIPTION
For now, we only ship `<build root>/{bin, lib}` and the few make build system
related files that are needed to support a simple

```
./configure [--prefix=PATH] && make install
```

workflow. The current binary distributions of GHC support a wider range
of parameters, but I figured it would be a good thing to start with this
and enhance it as we all see fit and perhaps using feedback from GHC HQ
(@bgamari in particular) and bindist users.

For reference, here's what the `configure` script advertises:

``` sh
$ ./configure --help
`configure' configures The Glorious Glasgow Haskell Compilation System 8.5.20180319 to adapt to many kinds of systems.

Usage: ./configure [OPTION]... [VAR=VALUE]...

To assign environment variables (e.g., CC, CFLAGS...), specify them as
VAR=VALUE.  See below for descriptions of some of the useful variables.

Defaults for the options are specified in brackets.

Configuration:
  -h, --help              display this help and exit
      --help=short        display options specific to this package
      --help=recursive    display the short help of all the included packages
  -V, --version           display version information and exit
  -q, --quiet, --silent   do not print `checking ...' messages
      --cache-file=FILE   cache test results in FILE [disabled]
  -C, --config-cache      alias for `--cache-file=config.cache'
  -n, --no-create         do not create output files
      --srcdir=DIR        find the sources in DIR [configure dir or `..']

Installation directories:
  --prefix=PREFIX         install architecture-independent files in PREFIX
                          [/usr/local]
  --exec-prefix=EPREFIX   install architecture-dependent files in EPREFIX
                          [PREFIX]

By default, `make install' will install all the files in
`/usr/local/bin', `/usr/local/lib' etc.  You can specify
an installation prefix other than `/usr/local' using `--prefix',
for instance `--prefix=$HOME'.

For better control, use the options below.

Fine tuning of the installation directories:
  --bindir=DIR            user executables [EPREFIX/bin]
  --sbindir=DIR           system admin executables [EPREFIX/sbin]
  --libexecdir=DIR        program executables [EPREFIX/libexec]
  --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
  --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
  --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
  --libdir=DIR            object code libraries [EPREFIX/lib]
  --includedir=DIR        C header files [PREFIX/include]
  --oldincludedir=DIR     C header files for non-gcc [/usr/include]
  --datarootdir=DIR       read-only arch.-independent data root [PREFIX/share]
  --datadir=DIR           read-only architecture-independent data [DATAROOTDIR]
  --infodir=DIR           info documentation [DATAROOTDIR/info]
  --localedir=DIR         locale-dependent data [DATAROOTDIR/locale]
  --mandir=DIR            man documentation [DATAROOTDIR/man]
  --docdir=DIR            documentation root
                          [DATAROOTDIR/doc/ghc-8.5.20180319]
  --htmldir=DIR           html documentation [DOCDIR]
  --dvidir=DIR            dvi documentation [DOCDIR]
  --pdfdir=DIR            pdf documentation [DOCDIR]
  --psdir=DIR             ps documentation [DOCDIR]

System types:
  --build=BUILD     configure for building on BUILD [guessed]
  --host=HOST       cross-compile to build programs to run on HOST [BUILD]
  --target=TARGET   configure for building compilers for TARGET [HOST]

Optional Features:
  --disable-option-checking  ignore unrecognized --enable/--with options
  --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
  --disable-ld-override   Prevent GHC from overriding the default linker used
                          by gcc. If ld-override is enabled GHC will try to
                          tell gcc to use whichever linker is selected by the
                          LD environment variable. [default=override enabled]

Optional Packages:
  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
  --with-gmp-includes     directory containing gmp.h
  --with-gmp-libraries    directory containing gmp library
  --with-hs-cpp=ARG       Path to the (C) preprocessor for Haskell files
                          [default=autodetect]
  --with-hs-cpp-flags=ARG Flags to the (C) preprocessor for Haskell files
                          [default=autodetect]

Some influential environment variables:
  CC          C compiler command
  CFLAGS      C compiler flags
  LDFLAGS     linker flags, e.g. -L<lib dir> if you have libraries in a
              nonstandard directory <lib dir>
  LIBS        libraries to pass to the linker, e.g. -l<library>
  CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
              you have headers in a nonstandard directory <include dir>
  CPP         C preprocessor

Use these variables to override the choices made by `configure' or to help
it to find libraries and programs with nonstandard names/locations.

Report bugs to <glasgow-haskell-bugs@haskell.org>.
```

while our trivial `Makefile` from this patch doesn't care about anything but `$prefix`.