### PR TITLE
Fix integer-gmp build

### DIFF
--- a/src/Rules/Gmp.hs
+++ b/src/Rules/Gmp.hs
@@ -45,7 +45,7 @@ gmpRules = do
     root <- buildRootRules
     root <//> gmpLibraryH %> \header -> do
         windows  <- windowsHost
-        configMk <- readFile' =<< (gmpBuildPath <&> (-/- "config.mk"))
+        configMk <- readFile' =<< (gmpBuildPath <&> (-/- "../config.mk"))
         if not windows && -- TODO: We don't use system GMP on Windows. Fix?
            any (`isInfixOf` configMk) [ "HaveFrameworkGMP = YES", "HaveLibGmp = YES" ]
         then do

--- a/src/Rules/Gmp.hs
+++ b/src/Rules/Gmp.hs
@@ -22,6 +22,7 @@ gmpLibrary = ".libs/libgmp.a"
 gmpContext :: Context
 gmpContext = vanillaContext Stage1 integerGmp
 
+-- TODO: Move this to a higher-level directory for simplicity.
 -- | Build directory for in-tree GMP library.
 gmpBuildPath :: Action FilePath
 gmpBuildPath = buildRoot <&> (-/- buildDir gmpContext -/- "gmp")
@@ -75,14 +76,13 @@ gmpRules = do
 
     -- This causes integerGmp package to be configured, hence creating the files
     root <//> "gmp/config.mk" %> \_ -> do
-        -- setup-config, triggers `ghc-cabal configure`
-        -- everything of a package should depend on that
-        -- in the first place.
+        -- Calling 'need' on @setup-config@, triggers @ghc-cabal configure@
+        -- Building anything in a package transitively depends on its configuration.
         setupConfig <- contextPath gmpContext <&> (-/- "setup-config")
         need [setupConfig]
 
-    -- Run GMP's configure script
     -- TODO: Get rid of hard-coded @gmp@.
+    -- Run GMP's configure script
     root <//> "gmp/Makefile" %> \mk -> do
         env     <- configureEnvironment
         gmpPath <- gmpBuildPath


### PR DESCRIPTION
Currently both Windows and Linux builds using `integer-gmp` are failing:
```
Error when running Shake build system:
* _build/stage1/lib/package.conf.d/integer-gmp-1.0.2.0.conf
* _build/stage1/libraries/integer-gmp/build/HSinteger-gmp-1.0.2.0.o
* _build/stage1/libraries/integer-gmp/build/gmp/include/ghc-gmp.h
* _build/stage1/libraries/integer-gmp/build/gmp/config.mk
Error, rule failed to build file:
  _build/stage1/libraries/integer-gmp/build/gmp/config.mk
CallStack (from HasCallStack):
  error, called at src\Development\Shake\Internal\Rules\File.hs:171:58 in shake-0.16-BDmtKOMxPdtLRnDkDJohXq:Development.Shake.Internal.Rules.File
```