### PR TITLE
Fix unlit by placing it under lib/bin/ instead of bin/

### DIFF
--- a/src/GHC.hs
+++ b/src/GHC.hs
@@ -131,8 +131,10 @@ programPath context@Context {..} = do
     -- The @touchy@ utility lives in the @lib/bin@ directory instead of @bin@,
     -- which is likely just a historical accident that will hopefully be fixed.
     -- See: https://github.com/snowleopard/hadrian/issues/570
-    path <- if package /= touchy then stageBinPath stage
-                                 else stageLibPath stage <&> (-/- "bin")
+    -- Likewise for 'unlit'.
+    path <- if package `elem` [touchy, unlit]
+      then stageLibPath stage <&> (-/- "bin")
+      else stageBinPath stage
     pgm  <- programName context
     return $ path -/- pgm <.> exe
 


### PR DESCRIPTION
A nicer fix would involve patching GHC to not just look under
$libexec/ but also under the directory where the GHC binary itself lives
(bin/ for hadrian), so that we can leave all binaries under bin/.

Addresses [Trac #15132](https://ghc.haskell.org/trac/ghc/ticket/15132).

Without this patch, this used to fail:
``` sh
$ echo '> main = putStrLn "hello"' > foo.lhs 
$ _build/stage1/bin/ghc foo.lhs
```

with an error saying that ghc could not find `unlit` at `_build/stage1/lib/bin/unlit`, where it expects it. With this patch, GHC successfully compiles that file.