### PR TITLE
Preliminary nofib rule

### DIFF
--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -62,6 +62,7 @@ executable hadrian
                        , Rules.Gmp
                        , Rules.Libffi
                        , Rules.Library
+                       , Rules.Nofib
                        , Rules.Program
                        , Rules.Register
                        , Rules.Selftest

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -10,6 +10,7 @@ import qualified Environment
 import qualified Rules
 import qualified Rules.Clean
 import qualified Rules.Documentation
+import qualified Rules.Nofib
 import qualified Rules.SourceDist
 import qualified Rules.Selftest
 import qualified Rules.Test
@@ -43,6 +44,7 @@ main = do
             Rules.buildRules
             Rules.Documentation.documentationRules
             Rules.Clean.cleanRules
+            Rules.Nofib.nofibRules
             Rules.oracleRules
             Rules.Selftest.selftestRules
             Rules.SourceDist.sourceDistRules

--- a/src/Rules/Nofib.hs
+++ b/src/Rules/Nofib.hs
@@ -1,0 +1,37 @@
+module Rules.Nofib where
+
+import Base
+import Expression
+import GHC.Packages
+import Oracles.Setting
+import Target
+import Utilities
+
+import System.Environment
+
+nofibRules :: Rules ()
+nofibRules = do
+  "nofib" ~> do
+    needNofibBuilders
+    makePath <- builderPath (Make "")
+    top <- topDirectory
+    root <- buildRoot
+    liftIO (setEnv "MAKE" makePath)
+
+    let out = top -/- root -/- "nofib.stdout"
+        err = top -/- root -/- "nofib.stderr"
+
+    buildWithCmdOptions [FileStdout out, FileStderr err] $
+      target (vanillaContext Stage2 compiler)
+             (Make "nofib")
+             []
+             [out, err]
+
+nofibHC :: FilePath -> String
+nofibHC ghcPath = "WithNofibHc=" ++ ghcPath
+
+perlProg :: FilePath -> String
+perlProg perlPath = "PERL=" ++ perlPath
+
+needNofibBuilders :: Action ()
+needNofibBuilders = needBuilder $ Ghc CompileHs Stage2

--- a/src/Settings/Builders/Make.hs
+++ b/src/Settings/Builders/Make.hs
@@ -1,5 +1,6 @@
 module Settings.Builders.Make (makeBuilderArgs) where
 
+import Builder
 import Rules.Gmp
 import Rules.Libffi
 import Settings.Builders.Common
@@ -9,8 +10,16 @@ makeBuilderArgs = do
     threads    <- shakeThreads <$> expr getShakeOptions
     gmpPath    <- expr gmpBuildPath
     libffiPath <- expr libffiBuildPath
+    ghcPath    <- expr $
+      (-/-) <$> topDirectory <*> builderPath (Ghc CompileHs Stage2)
+    perlPath   <- expr $ builderPath Perl
     let t = show $ max 4 (threads - 2) -- Don't use all Shake's threads
     mconcat
         [ builder (Make gmpPath          ) ? pure ["MAKEFLAGS=-j" ++ t]
         , builder (Make libffiPath       ) ? pure ["MAKEFLAGS=-j" ++ t, "install"]
-        , builder (Make "testsuite/tests") ? pure ["THREADS=" ++ t, "fast"] ]
+        , builder (Make "testsuite/tests") ? pure ["THREADS=" ++ t, "fast"]
+        , builder (Make "nofib"          ) ? pure
+            [ "WithNofibHc=" ++ ghcPath
+            , "PERL=" ++ perlPath
+            ]
+        ]


### PR DESCRIPTION
This doesn't yet capture stdout/stderr (nor does it `clean` or `boot`, even though I think & hope that the latter is done automatically), so we can't really use `nofib-analyse` yet (see [the nofib trac page](https://ghc.haskell.org/trac/ghc/wiki/Building/RunningNoFib)).

Still a WIP. Meant to address https://github.com/snowleopard/hadrian/issues/594.

@snowleopard Any guidance for the output capture bit? I would have thought the code in Nofib.hs would accomplish what I want (well, eventually I'll want stdout and stderr in the same file), but I can't see any `nofib.stdout`/`nofib.stderr` under my build root.