### PR TITLE
Add dependency on the new "llvm-passes" file.

### DIFF
--- a/src/Base.hs
+++ b/src/Base.hs
@@ -111,6 +111,7 @@ ghcDeps stage = mapM (\f -> stageLibPath stage <&> (-/- f))
       [ "ghc-usage.txt"
       , "ghci-usage.txt"
       , "llvm-targets"
+      , "llvm-passes"
       , "platformConstants"
       , "settings" ]
 

--- a/src/Rules/Generate.hs
+++ b/src/Rules/Generate.hs
@@ -164,6 +164,7 @@ copyRules = do
         prefix -/- "ghc-usage.txt"     <~ return "driver"
         prefix -/- "ghci-usage.txt"    <~ return "driver"
         prefix -/- "llvm-targets"      <~ return "."
+        prefix -/- "llvm-passes"       <~ return "."
         prefix -/- "platformConstants" <~ (buildRoot <&> (-/- generatedDir))
         prefix -/- "settings"          <~ return "."
         prefix -/- "template-hsc.h"    <~ return (pkgPath hsc2hs)

--- a/src/Rules/Program.hs
+++ b/src/Rules/Program.hs
@@ -45,7 +45,8 @@ buildProgram rs = do
                         need [template]
                     when (package == ghc) $ do
                         -- GHC depends on @settings@, @platformConstants@,
-                        -- @llvm-targets@, @ghc-usage.txt@, @ghci-usage.txt@.
+                        -- @llvm-targets@, @ghc-usage.txt@, @ghci-usage.txt@,
+                        -- @llvm-passes@.
                         need =<< ghcDeps stage
 
                     cross <- crossCompiling


### PR DESCRIPTION
This change updates Hadrian for an upcoming revision to GHC.

For details, see https://phabricator.haskell.org/D4695