### PR TITLE
do not always -Iincludes, addresses #608

### DIFF
--- a/src/Settings/Builders/Common.hs
+++ b/src/Settings/Builders/Common.hs
@@ -11,6 +11,7 @@ module Settings.Builders.Common (
 
 import Base
 import Expression
+import GHC.Packages
 import Hadrian.Haskell.Cabal.PackageData
 import Oracles.Flag
 import Oracles.Setting
@@ -27,7 +28,7 @@ cIncludeArgs = do
     iconvIncludeDir <- getSetting IconvIncludeDir
     gmpIncludeDir   <- getSetting GmpIncludeDir
     ffiIncludeDir   <- getSetting FfiIncludeDir
-    mconcat [ arg "-Iincludes"
+    mconcat [ notStage0 ||^ package compiler ? arg "-Iincludes"
             , arg $ "-I" ++ root -/- generatedDir
             , arg $ "-I" ++ path
             , pure . map ("-I"++) . filter (/= "") $ [iconvIncludeDir, gmpIncludeDir]


### PR DESCRIPTION
It turns out the ghc-heap we build with stage 0 ends up seeing `./includes` before it seems the boot compiler's includes, which causes problems with the recent SRT change that affects the representation of info tables. But when we build the ghc library with the boot compiler, we do need to see `./includes` first. Hence this patch, with which I have successfully run `./build.sh -j4 --flavour=quickest`.

@snowleopard Should most CI scripts be green if this patch indeed fixes our current problem(s) ?