### PR TITLE
Add `gmp` and `ncurses` as nix dependencies (#615)

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -76,6 +76,8 @@ in
         [ hadrianPackages.hadrian
           nixpkgs.arcanist
           nixpkgs.git
+          nixpkgs.gmp.dev nixpkgs.gmp.out
+          nixpkgs.ncurses.dev nixpkgs.ncurses.out
           nixpkgs.python3Packages.sphinx
           nixpkgs.texlive.combined.scheme-basic
           (nixpkgs.haskell.packages.ghc822.ghcWithPackages


### PR DESCRIPTION
Lifted from: https://github.com/alpmestan/ghc.nix/blob/master/default.nix

I'm not sure why I had to specify `.dev` and `.out`, but this is what worked for me