### PR TITLE
Bump shake version to 0.16.1.

### DIFF
--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -121,7 +121,7 @@ executable hadrian
                        , mtl                  == 2.2.*
                        , parsec               >= 3.1     && < 3.2
                        , QuickCheck           >= 2.6     && < 2.11
-                       , shake                == 0.16.*
+                       , shake                >= 0.16.1
                        , transformers         >= 0.4     && < 0.6
                        , unordered-containers >= 0.2.1   && < 0.3
     build-tools:         alex  >= 3.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ packages:
 - '../libraries/text'
 
 extra-deps:
-- shake-0.16
+- shake-0.16.1
 
 nix:
    enable: false


### PR DESCRIPTION
The shake-0.16 can't be built with ghc-8.4.3, due to the
Semigroup-Monoid-Proposal changes. shake-0.16.1 fixed that.