### PR TITLE
attempt at setting some more test arguments correctly

### DIFF
--- a/src/GHC.hs
+++ b/src/GHC.hs
@@ -107,6 +107,8 @@ stage2Packages = return [haddock]
 testsuitePackages :: Action [Package]
 testsuitePackages = return [ checkApiAnnotations
                            , checkPpr
+                           , ghcPkg
+                           , parallel
                            , hp2ps              ]
 
 -- | Given a 'Context', compute the name of the program that is built in it

--- a/src/Rules/Test.hs
+++ b/src/Rules/Test.hs
@@ -71,7 +71,12 @@ needTestsuiteBuilders = do
     need targets
   where
     needfile :: Stage -> Package -> Action FilePath
-    needfile stage pkg = programPath =<< programContext stage pkg
+    needfile stage pkg
+      -- TODO (Alp): we might sometimes need more than vanilla!
+      -- This should therefore depend on what test ways
+      -- we are going to use, I suppose?
+      | isLibrary pkg = pkgConfFile (Context stage pkg (read "v"))
+      | otherwise = programPath =<< programContext stage pkg
 
 needTestBuilders :: Action ()
 needTestBuilders = do

--- a/src/Rules/Test.hs
+++ b/src/Rules/Test.hs
@@ -75,7 +75,7 @@ needTestsuiteBuilders = do
       -- TODO (Alp): we might sometimes need more than vanilla!
       -- This should therefore depend on what test ways
       -- we are going to use, I suppose?
-      | isLibrary pkg = pkgConfFile (Context stage pkg (read "v"))
+      | isLibrary pkg = pkgConfFile (vanillaContext stage pkg)
       | otherwise = programPath =<< programContext stage pkg
 
 needTestBuilders :: Action ()


### PR DESCRIPTION
This patch adds 2 more packages (both required for at least some tests) and tries to set some more test options correctly, using the information we have from the `Flavour`. Feedback welcome! I'm not sure how reliable that is.