### PR TITLE
For executables, we should read the `main-is` field from the cabal file.

### DIFF
--- a/src/Hadrian/Haskell/Cabal/PackageData.hs
+++ b/src/Hadrian/Haskell/Cabal/PackageData.hs
@@ -10,6 +10,7 @@ data PackageData = PackageData
     , name            :: PackageName
     , version         :: String
     , componentId     :: String
+    , mainIs          :: Maybe (String, FilePath)  -- ("Main", filepath)
     , modules         :: [String]
     , otherModules    :: [String]
     , synopsis        :: String

--- a/src/Oracles/ModuleFiles.hs
+++ b/src/Oracles/ModuleFiles.hs
@@ -124,10 +124,15 @@ moduleFilesOracle = void $ do
     void . addOracle $ \(ModuleFiles (stage, package)) -> do
         let context = vanillaContext stage package
         srcDirs <- interpretInContext context (getPackageData PD.srcDirs)
+        mainIs  <- interpretInContext context (getPackageData PD.mainIs)
+        let removeMain = case mainIs of
+                              Just (mod, _) -> delete mod
+                              Nothing       -> id
         modules <- fmap sort $ interpretInContext context (getPackageData PD.modules)
         autogen <- autogenPath context
         let dirs = autogen : map (pkgPath package -/-) srcDirs
-            modDirFiles = groupSort $ map decodeModule modules
+            -- Don't resolve the file path for module `Main` twice.
+            modDirFiles = groupSort $ map decodeModule $ removeMain modules
         result <- concatForM dirs $ \dir -> do
             todo <- filterM (doesDirectoryExist . (dir -/-) . fst) modDirFiles
             forM todo $ \(mDir, mFiles) -> do
@@ -136,7 +141,16 @@ moduleFilesOracle = void $ do
                 let cmp f = compare (dropExtension f)
                     found = intersectOrd cmp files mFiles
                 return (map (fullDir -/-) found, mDir)
-        let pairs = sort [ (encodeModule d f, f) | (fs, d) <- result, f <- fs ]
+
+        mainpairs <- case mainIs of
+            Just (mod, filepath) ->
+                concatForM dirs $ \dir -> do
+                    found <- doesFileExist (dir -/- filepath)
+                    return $ if found then [(mod, unifyPath $ dir -/- filepath)]
+                                      else []
+            Nothing              -> return []
+
+        let pairs = sort $ mainpairs ++ [ (encodeModule d f, f) | (fs, d) <- result, f <- fs ]
             multi = [ (m, f1, f2) | (m, f1):(n, f2):_ <- tails pairs, m == n ]
         unless (null multi) $ do
             let (m, f1, f2) = head multi


### PR DESCRIPTION
Previously, we simply treat file name for `Main` module as `Main.hs` to build executables. That doesn't work for the `timeout` program. This patch fixes the problem.