### PR TITLE
Fix cabal sandbox init rule

### DIFF
--- a/build.cabal.sh
+++ b/build.cabal.sh
@@ -61,11 +61,12 @@ else
     if ! ( "$CABAL" sandbox hc-pkg list > /dev/null 2>&1); then
         "$CABAL" sandbox init
         "$CABAL" sandbox add-source ../libraries/Cabal/Cabal
-        "$CABAL" install                \
-            --dependencies-only         \
-            --disable-library-profiling \
-            --disable-shared
     fi
+
+    "$CABAL" install                \
+	--dependencies-only         \
+	--disable-library-profiling \
+	--disable-shared
 
     "$CABAL" run hadrian --            \
         --lint                         \

--- a/src/Rules/BinaryDist.hs
+++ b/src/Rules/BinaryDist.hs
@@ -15,6 +15,7 @@ bindistRules = do
       -- We 'need' all binaries and libraries
       targets <- mapM pkgTarget =<< stagePackages Stage1
       need targets
+
       version        <- setting ProjectVersion
       targetPlatform <- setting TargetPlatformFull
       hostOs         <- setting BuildOs

--- a/src/Rules/BinaryDist.hs
+++ b/src/Rules/BinaryDist.hs
@@ -15,7 +15,6 @@ bindistRules = do
       -- We 'need' all binaries and libraries
       targets <- mapM pkgTarget =<< stagePackages Stage1
       need targets
-
       version        <- setting ProjectVersion
       targetPlatform <- setting TargetPlatformFull
       hostOs         <- setting BuildOs


### PR DESCRIPTION
Fixes #524 #463

@snowleopard @angerman @izgzhen 

Test: Remove the local cabal sandbox, then run ./build.sh. Stop the process mid-installation, and then run the command again. Setup will start by installing the program where we previously stopped.