### PR TITLE
implement the equivalent of D4955 for hadrian

### DIFF
--- a/src/Settings/Packages.hs
+++ b/src/Settings/Packages.hs
@@ -79,7 +79,7 @@ packageArgs = do
             [ ghcWithNativeCodeGen ? arg "ncg"
             , ghcWithInterpreter ? notStage0 ? arg "ghci"
             , flag CrossCompiling ? arg "-terminfo"
-            , (stage == Stage2) ? arg "integer-simple" ]
+            , stage2 ? arg "integer-simple" ]
 
           , builder (Haddock BuildPackage) ? arg ("--optghc=-I" ++ path) ]
 

--- a/src/Settings/Packages.hs
+++ b/src/Settings/Packages.hs
@@ -75,10 +75,11 @@ packageArgs = do
             , ghcProfiled <$> flavour ?
               notStage0 ? arg "--ghc-pkg-option=--force" ]
 
-          , builder CabalFlags ? mconcat
+         , builder CabalFlags ? mconcat
             [ ghcWithNativeCodeGen ? arg "ncg"
             , ghcWithInterpreter ? notStage0 ? arg "ghci"
-            , flag CrossCompiling ? arg "-terminfo" ]
+            , flag CrossCompiling ? arg "-terminfo"
+            , (stage == Stage2) ? arg "integer-simple" ]
 
           , builder (Haddock BuildPackage) ? arg ("--optghc=-I" ++ path) ]
 


### PR DESCRIPTION
This addresses #642.

@snowleopard I'm using CabalFlags for now to keep it consistent. I also think it's not necessarily a good idea to throw everything at `GhcCabal Conf` instead, since we do not use ghc-cabal anymore. Since it's at least worth discussing, I just went with uniformity and passed the flags through `CabalFlags`.