### PR TITLE
Remove the hack to use a patched Cabal submodule in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,13 +104,6 @@ install:
     - mv .git ghc/hadrian
     - cd ghc/hadrian && git reset --hard HEAD && cd ..
 
-    # We checkout a patched Cabal.
-    # See: https://github.com/snowleopard/hadrian/issues/634
-    - cd libraries/Cabal/
-    - git remote add quasicomputational https://github.com/quasicomputational/cabal.git
-    - git fetch quasicomputational && git checkout cwd-independent-check
-    - cd ../../
-
 cache:
     directories:
         - $HOME/.cabal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,13 +20,6 @@ install:
     # Copy new Hadrian into ./ghc/hadrian
     - cp -r new-hadrian ghc\hadrian
 
-    # We checkout a patched Cabal.
-    # See: https://github.com/snowleopard/hadrian/issues/634
-    - cd ghc/libraries/Cabal/
-    - git remote add quasicomputational https://github.com/quasicomputational/cabal.git
-    - git fetch quasicomputational && git checkout cwd-independent-check
-    - cd ../../../
-
     # Install Alex and Happy
     - set PATH=C:\Users\appveyor\AppData\Roaming\local\bin;%PATH%
     - ghc\hadrian\stack install --install-ghc alex happy > nul

--- a/circle.yml
+++ b/circle.yml
@@ -31,10 +31,6 @@ compile:
     # in CircleCI is a separate process, thus you can't "cd" for the other lines
     - cd ghc/hadrian; git reset --hard HEAD
 
-    # We checkout a patched Cabal.
-    # See: https://github.com/snowleopard/hadrian/issues/634
-    - cd ghc/libraries/Cabal/ && git remote add quasicomputational https://github.com/quasicomputational/cabal.git && git fetch quasicomputational && git checkout cwd-independent-check
-
     - cd ghc; ./boot && PATH=~/.cabal/bin:$PATH ./configure
 
     # XXX: export PATH doesn't work well either, so we use inline env


### PR DESCRIPTION
The fix has landed in GHC HEAD.

Closes #634.