### PR TITLE
Clean up remaining bits of the install rule

### DIFF
--- a/cfg/system.config.in
+++ b/cfg/system.config.in
@@ -24,7 +24,6 @@ system-ghc-pkg = @GhcPkgCmd@
 tar            = @TarCmd@
 patch          = @PatchCmd@
 perl           = @PerlCmd@
-ln-s           = @LN_S@
 xelatex        = @XELATEX@
 
 # Python 3 is required to run test driver.
@@ -127,17 +126,3 @@ ffi-lib-dir       = @FFILibDir@
 
 with-libdw = @UseLibdw@
 have-lib-mingw-ex = @HaveLibMingwEx@
-
-# Installation:
-#=======================
-
-install-prefix          = @prefix@
-install-bindir          = @prefix@/bin
-install-libdir          = @prefix@/lib
-install-datarootdir     = @prefix@/share
-
-install         = @INSTALL@
-install-program = @INSTALL@ -m 755
-install-script  = @INSTALL@ -m 755
-install-data    = @INSTALL@ -m 644
-install-dir     = @INSTALL@ -m 755 -d

--- a/doc/user-settings.md
+++ b/doc/user-settings.md
@@ -186,11 +186,9 @@ verboseCommands = return True
 
 ## Miscellaneous
 
-By setting `stage1Only = True` you can disable building Stage2 GHC (i.e. the
-`ghc-stage2` executable) and Stage2 utilities, such as `haddock`. Note that all
-Stage0 and Stage1 libraries (including `compiler`) will still be built. Enabling
-this flag during installation leads to installing `ghc-stage1` instead of
-`ghc-stage2`, and `ghc-pkg` that was build with the Stage0 compiler.
+By setting `stage1Only = True` you can disable building Stage2 GHC and Stage2
+utilities such as `haddock`. Note that all Stage0 and Stage1 libraries will
+still be built.
 
 To change the default behaviour of Hadrian with respect to building split
 objects, override the `splitObjects` setting of the `Flavour` record:

--- a/src/CommandLine.hs
+++ b/src/CommandLine.hs
@@ -1,8 +1,7 @@
 module CommandLine (
     optDescrs, cmdLineArgsMap, cmdFlavour, lookupFreeze1, cmdIntegerSimple,
     cmdProgressColour, cmdProgressInfo, cmdConfigure, cmdSplitObjects,
-    cmdInstallDestDir, lookupBuildRoot, TestArgs(..), TestSpeed(..), 
-    defaultTestArgs
+    lookupBuildRoot, TestArgs(..), TestSpeed(..), defaultTestArgs
     ) where
 
 import Data.Either
@@ -20,7 +19,6 @@ data CommandLineArgs = CommandLineArgs
     { configure      :: Bool
     , flavour        :: Maybe String
     , freeze1        :: Bool
-    , installDestDir :: Maybe String
     , integerSimple  :: Bool
     , progressColour :: UseColour
     , progressInfo   :: ProgressInfo
@@ -35,7 +33,6 @@ defaultCommandLineArgs = CommandLineArgs
     { configure      = False
     , flavour        = Nothing
     , freeze1        = False
-    , installDestDir = Nothing
     , integerSimple  = False
     , progressColour = Auto
     , progressInfo   = Brief
@@ -91,9 +88,6 @@ readBuildRoot ms =
 readFreeze1 :: Either String (CommandLineArgs -> CommandLineArgs)
 readFreeze1 = Right $ \flags -> flags { freeze1 = True }
 
-readInstallDestDir :: Maybe String -> Either String (CommandLineArgs -> CommandLineArgs)
-readInstallDestDir ms = Right $ \flags -> flags { installDestDir = ms }
-
 readIntegerSimple :: Either String (CommandLineArgs -> CommandLineArgs)
 readIntegerSimple = Right $ \flags -> flags { integerSimple = True }
 
@@ -126,7 +120,7 @@ readSplitObjects :: Either String (CommandLineArgs -> CommandLineArgs)
 readSplitObjects = Right $ \flags -> flags { splitObjects = True }
 
 readTestCompiler :: Maybe String -> Either String (CommandLineArgs -> CommandLineArgs)
-readTestCompiler compiler = maybe (Left "Cannot parse compiler") (Right . set) compiler  
+readTestCompiler compiler = maybe (Left "Cannot parse compiler") (Right . set) compiler
   where
      set compiler  = \flags -> flags { testArgs = (testArgs flags) { testCompiler = compiler } }
 
@@ -139,10 +133,10 @@ readTestConfig config =
                         in flags { testArgs = (testArgs flags) { testConfigs = configs } }
 
 readTestConfigFile :: Maybe String -> Either String (CommandLineArgs -> CommandLineArgs)
-readTestConfigFile filepath = 
+readTestConfigFile filepath =
     maybe (Left "Cannot parse test-speed") (Right . set) filepath
   where
-    set filepath flags =  flags { testArgs = (testArgs flags) { testConfigFile = filepath } } 
+    set filepath flags =  flags { testArgs = (testArgs flags) { testConfigFile = filepath } }
 
 readTestJUnit :: Maybe String -> Either String (CommandLineArgs -> CommandLineArgs)
 readTestJUnit filepath = Right $ \flags -> flags { testArgs = (testArgs flags) { testJUnit = filepath } }
@@ -175,13 +169,13 @@ readTestVerbose :: Maybe String -> Either String (CommandLineArgs -> CommandLine
 readTestVerbose verbose = Right $ \flags -> flags { testArgs = (testArgs flags) { testVerbosity = verbose } }
 
 readTestWay :: Maybe String -> Either String (CommandLineArgs -> CommandLineArgs)
-readTestWay way = 
+readTestWay way =
     case way of
         Nothing -> Right id
-        Just way -> Right $ \flags -> 
+        Just way -> Right $ \flags ->
             let newWays = way : testWays (testArgs flags)
             in flags { testArgs = (testArgs flags) {testWays = newWays} }
- 
+
 -- | Standard 'OptDescr' descriptions of Hadrian's command line arguments.
 optDescrs :: [OptDescr (Either String (CommandLineArgs -> CommandLineArgs))]
 optDescrs =
@@ -193,8 +187,6 @@ optDescrs =
       "Build flavour (Default, Devel1, Devel2, Perf, Prof, Quick or Quickest)."
     , Option [] ["freeze1"] (NoArg readFreeze1)
       "Freeze Stage1 GHC."
-    , Option [] ["install-destdir"] (OptArg readInstallDestDir "DESTDIR")
-      "Installation destination directory."
     , Option [] ["integer-simple"] (NoArg readIntegerSimple)
       "Build GHC with integer-simple library."
     , Option [] ["progress-colour"] (OptArg readProgressColour "MODE")
@@ -225,7 +217,7 @@ optDescrs =
       "A verbosity value between 0 and 5. 0 is silent, 4 and higher activates extra output."
     , Option [] ["test-way"] (OptArg readTestWay "TEST_WAY")
       "only run these ways" ]
-    
+
 -- | A type-indexed map containing Hadrian command line arguments to be passed
 -- to Shake via 'shakeExtra'.
 cmdLineArgsMap :: IO (Map.HashMap TypeRep Dynamic)
@@ -252,9 +244,6 @@ lookupBuildRoot = buildRoot . lookupExtra defaultCommandLineArgs
 
 lookupFreeze1 :: Map.HashMap TypeRep Dynamic -> Bool
 lookupFreeze1 = freeze1 . lookupExtra defaultCommandLineArgs
-
-cmdInstallDestDir :: Action (Maybe String)
-cmdInstallDestDir = installDestDir <$> cmdLineArgs
 
 cmdIntegerSimple :: Action Bool
 cmdIntegerSimple = integerSimple <$> cmdLineArgs

--- a/src/GHC.hs
+++ b/src/GHC.hs
@@ -12,7 +12,7 @@ module GHC (
     testsuitePackages,
 
     -- * Package information
-    programName, nonHsMainPackage, autogenPath, installStage,
+    programName, nonHsMainPackage, autogenPath,
 
     -- * Miscellaneous
     programPath, buildDll0, rtsContext, rtsBuildPath, libffiContext,
@@ -133,16 +133,6 @@ programName Context {..} = do
                                 | p == runGhc -> "runhaskell"
                                 | p == iserv  -> "ghc-iserv"
                               _               ->  pkgName package
-
--- | The build stage whose results are used when installing a package, or
--- @Nothing@ if the package is not installed, e.g. because it is a user package.
--- The current implementation installs the /latest/ build stage of a package.
-installStage :: Package -> Action (Maybe Stage)
-installStage pkg
-    | not (isGhcPackage pkg) = return Nothing -- Only GHC packages are installed
-    | otherwise = do
-        stages <- filterM (fmap (pkg `elem`) . defaultPackages) [Stage0 ..]
-        return $ if null stages then Nothing else Just (maximum stages)
 
 -- | The 'FilePath' to a program executable in a given 'Context'.
 programPath :: Context -> Action FilePath

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -1,7 +1,7 @@
 module Settings (
     getArgs, getLibraryWays, getRtsWays, flavour, knownPackages,
-    findPackageByName, isLibrary, stagePackages,
-    programContext, getIntegerPackage, getDestDir
+    findPackageByName, isLibrary, stagePackages, programContext,
+    getIntegerPackage
     ) where
 
 import CommandLine
@@ -64,7 +64,3 @@ knownPackages = sort $ ghcPackages ++ userPackages
 -- Note: this is slow but we keep it simple as there are just ~50 packages
 findPackageByName :: PackageName -> Maybe Package
 findPackageByName name = find (\pkg -> pkgName pkg == name) knownPackages
-
--- | Install's DESTDIR setting.
-getDestDir :: Action FilePath
-getDestDir = fromMaybe "" <$> cmdInstallDestDir

--- a/src/Settings/Builders/Make.hs
+++ b/src/Settings/Builders/Make.hs
@@ -13,9 +13,8 @@ makeBuilderArgs = do
     libffiPath <- expr libffiBuildPath
     let t = show $ max 4 (threads - 2) -- Don't use all Shake's threads
     mconcat
-        [ builder (Make gmpPath          ) ? pure ["MAKEFLAGS=-j" ++ t]
-        , builder (Make libffiPath       ) ? pure ["MAKEFLAGS=-j" ++ t, "install"]
-        ]
+        [ builder (Make gmpPath   ) ? pure ["MAKEFLAGS=-j" ++ t]
+        , builder (Make libffiPath) ? pure ["MAKEFLAGS=-j" ++ t, "install"] ]
 
 validateBuilderArgs :: Args
 validateBuilderArgs = builder (Make "testsuite/tests") ? do
@@ -35,8 +34,8 @@ validateBuilderArgs = builder (Make "testsuite/tests") ? do
     fullpath :: Package -> Action FilePath
     fullpath pkg = programPath =<< programContext Stage1 pkg
 
--- | Support for speed of validation 
+-- | Support for speed of validation
 setTestSpeed :: TestSpeed -> String
 setTestSpeed Fast    = "fasttest"
 setTestSpeed Average = "test"
-setTestSpeed Slow    = "slowtest" 
+setTestSpeed Slow    = "slowtest"

--- a/src/Settings/Builders/RunTest.hs
+++ b/src/Settings/Builders/RunTest.hs
@@ -145,7 +145,7 @@ getTestArgs = do
 -- | inputs for these directory also. boilerplate soes not account for this
 -- | problem, but simply returns an error. How should we handle such cases?
 setBinaryDirectory :: String -> Action FilePath
-setBinaryDirectory "stage0" = setting InstallBinDir
+setBinaryDirectory "stage0" = takeDirectory <$> setting SystemGhc
 setBinaryDirectory "stage1" = liftM2 (-/-) topDirectory (stageBinPath Stage0)
 setBinaryDirectory "stage2" = liftM2 (-/-) topDirectory (stageBinPath Stage1)
 setBinaryDirectory compiler = pure $ parentPath compiler

--- a/src/Settings/Packages.hs
+++ b/src/Settings/Packages.hs
@@ -193,8 +193,6 @@ rtsPackageArgs = package rts ? do
     libffiName     <- expr libffiLibraryName
     ffiIncludeDir  <- getSetting FfiIncludeDir
     ffiLibraryDir  <- getSetting FfiLibDir
-    ghclibDir      <- expr installGhcLibDir
-    destDir        <- expr getDestDir
     let cArgs = mconcat
           [ arg "-Irts"
           , rtsWarnings
@@ -297,13 +295,6 @@ rtsPackageArgs = package rts ? do
           , "-DFFI_INCLUDE_DIR=" ++ show ffiIncludeDir
           , "-DFFI_LIB_DIR="     ++ show ffiLibraryDir
           , "-DFFI_LIB="         ++ show libffiName ]
-
-        , builder HsCpp ?
-          input "//package.conf.in" ?
-          output "//package.conf.install.raw" ?
-          pure [ "-DINSTALLING"
-               , "-DLIB_DIR=\"" ++ destDir ++ ghclibDir ++ "\""
-               , "-DINCLUDE_DIR=\"" ++ destDir ++ ghclibDir -/- "include\"" ]
 
         , builder HsCpp ? flag HaveLibMingwEx ? arg "-DHAVE_LIBMINGWEX" ]
 


### PR DESCRIPTION
#531 removed install rules (`src/Rules/Install.hs`), but left a lot of supporting code that is now unused.

Hopefully, this clean up completes the removal of install rules. If they are ever coming back to Hadrian in any shape, some useful code can be recovered here.

See #540.