### PR TITLE
address some issues with the testsuite rules

### DIFF
--- a/src/Rules/Test.hs
+++ b/src/Rules/Test.hs
@@ -29,6 +29,7 @@ testRules = do
     -- | Using program shipped with testsuite to generate ghcconfig file.
     root -/- ghcConfigProgPath ~> do
         ghc <- builderPath $ Ghc CompileHs Stage0
+        createDirectory $ takeDirectory (root -/- ghcConfigProgPath)
         cmd ghc [ghcConfigHsPath, "-o" , root -/- ghcConfigProgPath]
 
     -- | TODO : Use input test compiler and not just stage2 compiler.

--- a/src/Settings/Builders/RunTest.hs
+++ b/src/Settings/Builders/RunTest.hs
@@ -94,18 +94,18 @@ runTestBuilderArgs = builder RunTest ? do
             , arg "-e", arg $ "config.cleanup=False" -- Don't clean up.
             , arg "-e", arg $ "config.compiler_debugged=" ++ quote (yesNo debugged)
             , arg "-e", arg $ "ghc_debugged=" ++ quote (yesNo debugged)
-            , arg "-e", arg $ asZeroOne "ghc_with_native_codegen" withNativeCodeGen
+            , arg "-e", arg $ asZeroOne "ghc_with_native_codegen=" withNativeCodeGen
 
             , arg "-e", arg $ "config.have_interp=" ++ show withInterpreter
             , arg "-e", arg $ "config.unregisterised=" ++ show unregisterised
 
             , arg "-e", arg $ "ghc_compiler_always_flags=" ++ quote ghcFlags
-            , arg "-e", arg $ asZeroOne "ghc_with_dynamic_rts"  (hasRtsWay "dyn")
-            , arg "-e", arg $ asZeroOne "ghc_with_threaded_rts" (hasRtsWay "thr")
-            , arg "-e", arg $ asZeroOne "config.have_vanilla"   (hasLibWay vanilla)
-            , arg "-e", arg $ asZeroOne "config.have_dynamic"   (hasLibWay dynamic)
-            , arg "-e", arg $ asZeroOne "config.have_profiling" (hasLibWay profiling)
-            , arg "-e", arg $ asZeroOne "ghc_with_smp" withSMP
+            , arg "-e", arg $ asZeroOne "ghc_with_dynamic_rts="  (hasRtsWay "dyn")
+            , arg "-e", arg $ asZeroOne "ghc_with_threaded_rts=" (hasRtsWay "thr")
+            , arg "-e", arg $ asZeroOne "config.have_vanilla="   (hasLibWay vanilla)
+            , arg "-e", arg $ asZeroOne "config.have_dynamic="   (hasLibWay dynamic)
+            , arg "-e", arg $ asZeroOne "config.have_profiling=" (hasLibWay profiling)
+            , arg "-e", arg $ asZeroOne "ghc_with_smp=" withSMP
             , arg "-e", arg $ "ghc_with_llvm=0" -- TODO: support LLVM
 
             , arg "-e", arg $ "config.ghc_dynamic_by_default=" ++ show hasDynamicByDefault

--- a/src/Settings/Default.hs
+++ b/src/Settings/Default.hs
@@ -133,6 +133,7 @@ testsuitePackages = do
              , ghci
              , ghcPkg
              , hp2ps
+             , hsc2hs
              , iserv
              , parallel
              , runGhc        ] ++


### PR DESCRIPTION
The driver was invoked with invalid syntax for some arguments, we were not
making sure hsc2hs is built before we run the tests (it's needed by many), etc.

This kills about ~500 unexpected failures.