### PR TITLE
remove superfluous -fno-{ignore, omit}-interface-pragmas

### DIFF
--- a/src/Settings/Packages.hs
+++ b/src/Settings/Packages.hs
@@ -27,13 +27,6 @@ packageArgs = do
           -- This fixes the 'unknown symbol stat' issue.
           -- See: https://github.com/snowleopard/hadrian/issues/259.
           , builder (Ghc CompileCWithGhc) ? arg "-optc-O2"
-
-          -- See https://ghc.haskell.org/trac/ghc/ticket/15286 and
-          -- https://phabricator.haskell.org/D4880
-          , builder (Ghc CompileHs) ? mconcat
-             [ input "//Natural.hs" ? pure ["-fno-omit-interface-pragmas"]
-             , input "//Num.hs" ? pure ["-fno-ignore-interface-pragmas"]
-             ]
           ]
         ------------------------------ bytestring ------------------------------
         , package bytestring ?
@@ -53,7 +46,7 @@ packageArgs = do
           , builder (Ghc CompileHs) ? mconcat
             [ inputs ["//GHC.hs", "//GhcMake.hs"] ? arg "-fprof-auto"
             , input "//Parser.hs" ?
-              pure ["-fno-ignore-interface-pragmas", "-fcmm-sink" ] ]
+              pure ["-fcmm-sink" ] ]
 
           , builder (Cabal Setup) ? mconcat
             [ arg $ "--ghc-option=-DSTAGE=" ++ show (fromEnum stage + 1)


### PR DESCRIPTION
As suggested by @sighingnow in https://github.com/snowleopard/hadrian/pull/674#issuecomment-418656150. I ran the testsuite after I wrote this patch, and this doesn't affect _anything_.