### PR TITLE
Work around the "can't use natural in base" problem on a per-flavour basis

### DIFF
--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -87,6 +87,7 @@ executable hadrian
                        , Settings.Builders.RunTest
                        , Settings.Builders.Xelatex
                        , Settings.Default
+                       , Settings.Flavours.Common
                        , Settings.Flavours.Development
                        , Settings.Flavours.Performance
                        , Settings.Flavours.Profiled

--- a/src/Settings/Flavours/Common.hs
+++ b/src/Settings/Flavours/Common.hs
@@ -4,8 +4,8 @@ import Expression
 
 -- See https://ghc.haskell.org/trac/ghc/ticket/15286 and
 -- https://phabricator.haskell.org/D4880
-naturalInBaseFixArgs :: [Args]
-naturalInBaseFixArgs =
+naturalInBaseFixArgs :: Args
+naturalInBaseFixArgs = mconcat
   [ input "//Natural.hs" ? pure ["-fno-omit-interface-pragmas"]
   , input "//Num.hs" ? pure ["-fno-ignore-interface-pragmas"]
   ]

--- a/src/Settings/Flavours/Common.hs
+++ b/src/Settings/Flavours/Common.hs
@@ -1,0 +1,11 @@
+module Settings.Flavours.Common where
+
+import Expression
+
+-- See https://ghc.haskell.org/trac/ghc/ticket/15286 and
+-- https://phabricator.haskell.org/D4880
+naturalInBaseFixArgs :: [Args]
+naturalInBaseFixArgs =
+  [ input "//Natural.hs" ? pure ["-fno-omit-interface-pragmas"]
+  , input "//Num.hs" ? pure ["-fno-ignore-interface-pragmas"]
+  ]

--- a/src/Settings/Flavours/Profiled.hs
+++ b/src/Settings/Flavours/Profiled.hs
@@ -14,9 +14,10 @@ profiledFlavour = defaultFlavour
 
 profiledArgs :: Args
 profiledArgs = sourceArgs SourceArgs
-    { hsDefault  = mconcat $
+    { hsDefault  = mconcat
         [ pure ["-O0", "-H64m"]
-        ] ++ naturalInBaseFixArgs
+        , naturalInBaseFixArgs
+        ]
     , hsLibrary  = notStage0 ? arg "-O"
     , hsCompiler = arg "-O"
     , hsGhc      = arg "-O" }

--- a/src/Settings/Flavours/Profiled.hs
+++ b/src/Settings/Flavours/Profiled.hs
@@ -3,6 +3,7 @@ module Settings.Flavours.Profiled (profiledFlavour) where
 import Expression
 import Flavour
 import {-# SOURCE #-} Settings.Default
+import Settings.Flavours.Common (naturalInBaseFixArgs)
 
 -- Please update doc/flavours.md when changing this file.
 profiledFlavour :: Flavour
@@ -13,7 +14,9 @@ profiledFlavour = defaultFlavour
 
 profiledArgs :: Args
 profiledArgs = sourceArgs SourceArgs
-    { hsDefault  = pure ["-O0", "-H64m"]
+    { hsDefault  = mconcat $
+        [ pure ["-O0", "-H64m"]
+        ] ++ naturalInBaseFixArgs
     , hsLibrary  = notStage0 ? arg "-O"
     , hsCompiler = arg "-O"
     , hsGhc      = arg "-O" }

--- a/src/Settings/Flavours/Quick.hs
+++ b/src/Settings/Flavours/Quick.hs
@@ -19,7 +19,8 @@ quickArgs :: Args
 quickArgs = sourceArgs SourceArgs
     { hsDefault  = mconcat $
         [ pure ["-O0", "-H64m"]
-        ] ++ naturalInBaseFixArgs
+        , naturalInBaseFixArgs
+        ]
     , hsLibrary  = notStage0 ? arg "-O"
     , hsCompiler =    stage0 ? arg "-O"
     , hsGhc      =    stage0 ? arg "-O" }

--- a/src/Settings/Flavours/Quick.hs
+++ b/src/Settings/Flavours/Quick.hs
@@ -4,6 +4,7 @@ import Expression
 import Flavour
 import Oracles.Flag
 import {-# SOURCE #-} Settings.Default
+import Settings.Flavours.Common (naturalInBaseFixArgs)
 
 -- Please update doc/flavours.md when changing this file.
 quickFlavour :: Flavour
@@ -16,7 +17,9 @@ quickFlavour = defaultFlavour
 
 quickArgs :: Args
 quickArgs = sourceArgs SourceArgs
-    { hsDefault  = pure ["-O0", "-H64m"]
+    { hsDefault  = mconcat $
+        [ pure ["-O0", "-H64m"]
+        ] ++ naturalInBaseFixArgs
     , hsLibrary  = notStage0 ? arg "-O"
     , hsCompiler =    stage0 ? arg "-O"
     , hsGhc      =    stage0 ? arg "-O" }

--- a/src/Settings/Flavours/QuickCross.hs
+++ b/src/Settings/Flavours/QuickCross.hs
@@ -4,6 +4,7 @@ import Expression
 import Flavour
 import Oracles.Flag
 import {-# SOURCE #-} Settings.Default
+import Settings.Flavours.Common
 
 -- Please update doc/flavours.md when changing this file.
 quickCrossFlavour :: Flavour
@@ -16,7 +17,10 @@ quickCrossFlavour = defaultFlavour
 
 quickCrossArgs :: Args
 quickCrossArgs = sourceArgs SourceArgs
-    { hsDefault  = pure ["-O0", "-H64m"]
+    { hsDefault  = mconcat $
+        [ pure ["-O0", "-H64m"]
+        , naturalInBaseFixArgs
+        ]
     , hsLibrary  = notStage0 ? mconcat [ arg "-O", arg "-fllvm" ]
     , hsCompiler = stage0 ? arg "-O"
     , hsGhc      = mconcat

--- a/src/Settings/Flavours/Quickest.hs
+++ b/src/Settings/Flavours/Quickest.hs
@@ -17,7 +17,8 @@ quickestArgs :: Args
 quickestArgs = sourceArgs SourceArgs
     { hsDefault  = mconcat $
         [ pure ["-O0", "-H64m"]
-        ] ++ naturalInBaseFixArgs
+        , naturalInBaseFixArgs
+        ]
     , hsLibrary  = mempty
     , hsCompiler = stage0 ? arg "-O"
     , hsGhc      = stage0 ? arg "-O" }

--- a/src/Settings/Flavours/Quickest.hs
+++ b/src/Settings/Flavours/Quickest.hs
@@ -3,6 +3,7 @@ module Settings.Flavours.Quickest (quickestFlavour) where
 import Expression
 import Flavour
 import {-# SOURCE #-} Settings.Default
+import Settings.Flavours.Common (naturalInBaseFixArgs)
 
 -- Please update doc/flavours.md when changing this file.
 quickestFlavour :: Flavour
@@ -14,7 +15,9 @@ quickestFlavour = defaultFlavour
 
 quickestArgs :: Args
 quickestArgs = sourceArgs SourceArgs
-    { hsDefault  = pure ["-O0", "-H64m"]
+    { hsDefault  = mconcat $
+        [ pure ["-O0", "-H64m"]
+        ] ++ naturalInBaseFixArgs
     , hsLibrary  = mempty
     , hsCompiler = stage0 ? arg "-O"
     , hsGhc      = stage0 ? arg "-O" }


### PR DESCRIPTION
The only flavours that need the workaround are the ones that build
GHC/{Natural, Num}.hs with -O0, namely 'quick', 'quickest' and 'prof'.
This patches defines the necessary arguments in one place and uses them
in all the aforementionned flavour definitions.

This will allow us to have both quick/quickest/prof builds that come through
as well as an efficient compiler when we want it (with e.g perf), which wasn't
the case before my series of patches for this problem.