### PR TITLE
Make the test rule depend on ghc-compact, to make this library's tests pass

### DIFF
--- a/src/Settings/Default.hs
+++ b/src/Settings/Default.hs
@@ -131,6 +131,7 @@ testsuitePackages = do
     return $ [ checkApiAnnotations
              , checkPpr
              , ghci
+             , ghcCompact
              , ghcPkg
              , hp2ps
              , hsc2hs

--- a/src/Settings/Packages.hs
+++ b/src/Settings/Packages.hs
@@ -26,15 +26,8 @@ packageArgs = do
 
           -- This fixes the 'unknown symbol stat' issue.
           -- See: https://github.com/snowleopard/hadrian/issues/259.
-          , builder (Ghc CompileCWithGhc) ? arg "-optc-O2"
+          , builder (Ghc CompileCWithGhc) ? arg "-optc-O2" ]
 
-          -- See https://ghc.haskell.org/trac/ghc/ticket/15286 and
-          -- https://phabricator.haskell.org/D4880
-          , builder (Ghc CompileHs) ? mconcat
-             [ input "//Natural.hs" ? pure ["-fno-omit-interface-pragmas"]
-             , input "//Num.hs" ? pure ["-fno-ignore-interface-pragmas"]
-             ]
-          ]
         ------------------------------ bytestring ------------------------------
         , package bytestring ?
           builder (Cabal Flags) ? intLib == integerSimple ? arg "integer-simple"


### PR DESCRIPTION
This commit also removes some leftover from my previous PR, sorry about that.