### PR TITLE
Move to GHC 8.4.3 by upgrading the Stackage snapshot

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-10.8
+resolver: lts-12.9
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
At least compiles Hadrian itself, so this seems like a much better prospect - as it is Hadrian is close to getting outside the GHC support Window of last 2 versions.