### PR TITLE
set integer-gmp flag when appropriate, when building the compiler lib

### DIFF
--- a/src/Settings/Packages.hs
+++ b/src/Settings/Packages.hs
@@ -71,7 +71,8 @@ packageArgs = do
             [ ghcWithNativeCodeGen ? arg "ncg"
             , ghcWithInterpreter ? notStage0 ? arg "ghci"
             , flag CrossCompiling ? arg "-terminfo"
-            , stage2 ? arg "integer-simple" ]
+            , notStage0 ? intLib == integerGmp ?
+              arg "integer-gmp" ]
 
           , builder (Haddock BuildPackage) ? arg ("--optghc=-I" ++ path) ]
 

--- a/src/Settings/Packages.hs
+++ b/src/Settings/Packages.hs
@@ -22,7 +22,7 @@ packageArgs = do
     mconcat
         --------------------------------- base ---------------------------------
         [ package base ? mconcat
-          [ builder (Cabal Flags) ? arg ('+' : pkgName intLib)
+          [ builder (Cabal Flags) ? notStage0 ? arg (pkgName intLib)
 
           -- This fixes the 'unknown symbol stat' issue.
           -- See: https://github.com/snowleopard/hadrian/issues/259.


### PR DESCRIPTION
This among other things has the effect of giving a correct output for many tests (see RtClosureInspect.hs to see pretty-printing code that's enabled when the integer-gmp flag is enabled (which in turns defines the `INTEGER_GMP` macro)), but is anyway the correct thing to do.