### PR TITLE
fix a logic error that kept us from building/linking object files for many ways

### DIFF
--- a/src/Rules/Library.hs
+++ b/src/Rules/Library.hs
@@ -92,7 +92,7 @@ cObjects :: Context -> Action [FilePath]
 cObjects context = do
     srcs <- interpretInContext context (getPackageData PD.cSrcs)
     objs <- mapM (objectPath context) srcs
-    return $ if way context == threaded
+    return $ if Threaded `wayUnit` way context
         then objs
         else filter ((`notElem` ["Evac_thr", "Scav_thr"]) . takeBaseName) objs
 


### PR DESCRIPTION
It's the obvious error that we've made a few times already. "way == something" instead of "way contains ...".

This was causing linker errors and what not for several tests, which are now fixed, with this patch.