### PR TITLE
add unlit to testsuitePackages

### DIFF
--- a/src/Settings/Default.hs
+++ b/src/Settings/Default.hs
@@ -137,7 +137,8 @@ testsuitePackages = do
              , hsc2hs
              , iserv
              , parallel
-             , runGhc        ] ++
+             , runGhc
+             , unlit         ] ++
              [ timeout | win ]
 
 -- | Default build ways for library packages:


### PR DESCRIPTION
This fixes 11 unexpected failures when running the testsuite -- all due to unlit not being built.