### PR TITLE
pass 'threaded' flag for the GHC executable, to link against the threaded RTS

### DIFF
--- a/src/Settings/Packages.hs
+++ b/src/Settings/Packages.hs
@@ -82,7 +82,11 @@ packageArgs = do
 
           , builder (Cabal Flags) ? mconcat
             [ ghcWithInterpreter ? notStage0 ? arg "ghci"
-            , flag CrossCompiling ? arg "-terminfo" ] ]
+            , flag CrossCompiling ? arg "-terminfo"
+            -- the 'threaded' flag is True by default, but
+            -- let's record explicitly that we link all ghc
+            -- executables with the threaded runtime.
+            , arg "threaded" ] ]
 
         -------------------------------- ghcPkg --------------------------------
         , package ghcPkg ?


### PR DESCRIPTION
This goes hand in hand with https://phabricator.haskell.org/D5146
I'm trying to get the `findPtr` fix landed in master so that we can switch CI back to whatever GHC HEAD is. This way, we could even wait for D5146 to be merged before re-running CI for this patch and making sure that nothing is broken, if we so desire.

We could have a shorter term hack of just passing -threaded ourself explicitly in the right place, but it's a lot hackier and I suspect the diff will not take months to be merged.

This should in theory fix the failure of T8242 (when testing a GHC built by hadrian of course):

``` sh
$ "/home/alp/WT/ghc-hadrian/_tmp/stage1/bin/ghc" T8242.hs -dcore-lint -dcmm-lint -no-user-package-db -rtsopts -fno-warn-missed-specialisations -fshow-warning-groups -fdiagnostics-color=never -fno-diagnostics-show-caret -dno-debug-output  --interactive -v0 -ignore-dot-ghci -fno-ghci-history +RTS -I0.1 -RTS < T8242.genscript
T8242: setNumCapabilities: not supported in the non-threaded RTS
```

I launched a build with both this patch and the GHC one locally, it'll run T8242 at the end, I'll report back with the result.