### PR TITLE
OS X CI scripts: don't use my GHC branch anymore, D5138 has been merged

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,11 +70,8 @@ matrix:
               - brew upgrade python
 
           script:
-              - git remote add alp https://github.com/alpmestan/ghc.git
-              - git fetch alp
-              - git checkout alp/osx-findPtr
               # Due to timeout limit of OS X build on Travis CI,
-              # we will ignore selftest and build only stage1
+              # we will ignore selftest
               - hadrian/build.sh -j -c $MODE --no-progress --progress-colour=never --profile=-
 
               # Test GHC binary

--- a/circle.yml
+++ b/circle.yml
@@ -30,8 +30,6 @@ compile:
     # NOTE: we must write them in the same line because each line
     # in CircleCI is a separate process, thus you can't "cd" for the other lines
     - cd ghc/hadrian; git reset --hard HEAD
-    - cd ghc; git remote add alp https://github.com/alpmestan/ghc.git
-    - cd ghc; git fetch alp; git checkout alp/osx-findPtr
     - cd ghc; ./boot && PATH=~/.cabal/bin:$PATH ./configure
 
     # XXX: export PATH doesn't work well either, so we use inline env


### PR DESCRIPTION
https://phabricator.haskell.org/D5138

Future CI runs (including the ones for this patch, hopefully) should just work again since the `findPtr` fix landed in master.