### PR TITLE
Simplify oracles

### DIFF
--- a/src/Hadrian/Oracles/Cabal/Rules.hs
+++ b/src/Hadrian/Oracles/Cabal/Rules.hs
@@ -36,21 +36,19 @@ import Hadrian.Utilities
 -- 3) 'Hadrian.Oracles.Cabal.configurePackageGHC' that configures a package.
 cabalOracle :: Rules ()
 cabalOracle = do
-    packageData <- newCache $ \package -> do
+    void $ addOracleCache $ \(PackageDataKey package) -> do
         let file = pkgCabalFile package
         need [file]
         putLoud $ "| PackageData oracle: parsing " ++ quote file ++ "..."
         parsePackageData package
-    void $ addOracleCache $ \(PackageDataKey package) -> packageData package
 
-    contextData <- newCache $ \(context@Context {..}) -> do
+    void $ addOracleCache $ \(ContextDataKey context@Context {..}) -> do
         putLoud $ "| ContextData oracle: resolving data for "
                ++ quote (pkgName package) ++ " (" ++ show stage
                ++ ", " ++ show way ++ ")..."
         resolveContextData context
-    void $ addOracleCache $ \(ContextDataKey context) -> contextData context
 
-    conf <- newCache $ \(pkg, stage) -> do
+    void $ addOracleCache $ \(PackageConfigurationKey (pkg, stage)) -> do
         putLoud $ "| PackageConfiguration oracle: configuring "
                ++ quote (pkgName pkg) ++ " (" ++ show stage ++ ")..."
         -- Configure the package with the GHC corresponding to the given stage
@@ -60,4 +58,3 @@ cabalOracle = do
         let platform = fromMaybe (error msg) maybePlatform
             msg      = "PackageConfiguration oracle: cannot detect platform"
         return $ PackageConfiguration (compiler, platform)
-    void $ addOracleCache $ \(PackageConfigurationKey pkgStage) -> conf pkgStage

--- a/src/Hadrian/Oracles/TextFile.hs
+++ b/src/Hadrian/Oracles/TextFile.hs
@@ -66,10 +66,6 @@ lookupDependencies depFile file = do
         Just [] -> error $ "No source file found for file " ++ quote file
         Just (source : files) -> return (source, files)
 
-newtype TextFile = TextFile FilePath
-    deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
-type instance RuleResult TextFile = String
-
 newtype KeyValue = KeyValue (FilePath, String)
     deriving (Binary, Eq, Hashable, NFData, Show, Typeable)
 type instance RuleResult KeyValue = Maybe String
@@ -90,12 +86,6 @@ type instance RuleResult KeyValues = Maybe [String]
 --    see 'lookupDependencies'.
 textFileOracle :: Rules ()
 textFileOracle = do
-    text <- newCache $ \file -> do
-        need [file]
-        putLoud $ "| TextFile oracle: reading " ++ quote file ++ "..."
-        liftIO $ readFile file
-    void $ addOracleCache $ \(TextFile file) -> text file
-
     kv <- newCache $ \file -> do
         need [file]
         putLoud $ "| KeyValue oracle: reading " ++ quote file ++ "..."


### PR DESCRIPTION
As discussed in #550, we can remove some unnecessary occurrences of `newCache`.