### PR TITLE
hadrian.cabal: update Cabal bounds

### DIFF
--- a/hadrian.cabal
+++ b/hadrian.cabal
@@ -114,7 +114,7 @@ executable hadrian
     other-extensions:    MultiParamTypeClasses
                        , TypeFamilies
     build-depends:       base                 >= 4.8     && < 5
-                       , Cabal                >= 2.4     && < 2.5
+                       , Cabal                >= 2.5     && < 2.6
                        , containers           == 0.5.*
                        , directory            >= 1.2     && < 1.4
                        , extra                >= 1.4.7


### PR DESCRIPTION
The recent `Cabal` submodule bump (https://github.com/ghc/ghc/commit/fa1c8279ada1e9f9ee34056de5be3b043b469f05) means we cannot build hadrian as things stand right now. This fixes the problem.