### PR TITLE
Implement better fix for the OS X / findPtr issue

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,7 @@ dependencies:
     - ~/.ghc
     - /usr/local/Cellar
 
+
 compile:
   override:
     # Fetch GHC sources into ./ghc
@@ -30,6 +31,8 @@ compile:
     # NOTE: we must write them in the same line because each line
     # in CircleCI is a separate process, thus you can't "cd" for the other lines
     - cd ghc/hadrian; git reset --hard HEAD
+    - cd ghc; git remote add alp https://github.com/alpmestan/ghc.git; git fetch alp
+    - cd ghc; git checkout alp/better-findPtr-workaround
     - cd ghc; ./boot && PATH=~/.cabal/bin:$PATH ./configure
 
     # XXX: export PATH doesn't work well either, so we use inline env

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   xcode:
     version: 8.0
   environment:
-    MODE: --flavour=quickest --integer-simple
+    MODE: --flavour=quickest # --integer-simple
 
 dependencies:
   override:


### PR DESCRIPTION
This is an alternative solution to https://github.com/snowleopard/hadrian/issues/614.

@Mistuke pointed out [here](https://phabricator.haskell.org/rGHC900c47f88784) that the solution I went with (always include findPtr/_findPtr) has its own problems, and suggested a better one. I implemented just that in https://github.com/alpmestan/ghc/commit/f78e0ae443f48bb2c58819f04d781a3d27c2d528.

Note that the hadrian build should "just" pick up the fix, since we already pass the `debug` flag whenever appropriate for our `extra-library-flavours` business. Let's see what the OS X builds say. When I get them to work, I'll submit the GHC patch, and when it's merged, we can just close this PR I suppose, since there's nothing to change in hadrian land. :-)